### PR TITLE
feat: auto-select language from URL query parameter

### DIFF
--- a/packages/data/src/load/utils.ts
+++ b/packages/data/src/load/utils.ts
@@ -10,7 +10,7 @@ export const autoSelectLanguage = (languageService: LanguageService) => {
 
   const languages = languageService.getLanguages();
 
-  const search = typeof window !== 'undefined' ? window.location.search : '';
+  const search = globalThis?.location?.search ?? '';
   const params = new URLSearchParams(search);
   const languageParam = params.get('language');
   if (languageParam && languages.some((l) => l.language === languageParam)) {

--- a/packages/data/src/load/utils.ts
+++ b/packages/data/src/load/utils.ts
@@ -1,12 +1,24 @@
 import { LanguageService } from '../domain';
 
 /**
- * If only one language is available and no language is set, set that language automatically
- * and prevent the language selection screen from showing up.
+ * If no language is set, try to auto-select one:
+ * 1. From the URL query parameter `?language=de`
+ * 2. If only one language is available, select it automatically
  */
 export const autoSelectLanguage = (languageService: LanguageService) => {
+  if (languageService.hasLanguage()) return;
+
   const languages = languageService.getLanguages();
-  if (!languageService.hasLanguage() && languages.length === 1) {
+
+  const search = typeof window !== 'undefined' ? window.location.search : '';
+  const params = new URLSearchParams(search);
+  const languageParam = params.get('language');
+  if (languageParam && languages.some((l) => l.language === languageParam)) {
+    languageService.changeLanguage(languageParam);
+    return;
+  }
+
+  if (languages.length === 1) {
     languageService.changeLanguage(languages[0].language);
   }
 };

--- a/packages/data/test/load/utils.test.ts
+++ b/packages/data/test/load/utils.test.ts
@@ -6,15 +6,16 @@ import { autoSelectLanguage } from '../../src/load/utils';
 describe('autoSelectLanguage', () => {
   let memoryStorage: MemoryStorage;
   let service: LanguageService;
+  const originalLocation = globalThis.location;
 
   beforeEach(() => {
     memoryStorage = new MemoryStorage();
     service = new LanguageService(memoryStorage);
-    (globalThis as any).window = { location: { search: '' } };
+    (globalThis as any).location = { search: '' };
   });
 
   afterEach(() => {
-    delete (globalThis as any).window;
+    (globalThis as any).location = originalLocation;
   });
 
   function setLanguages(languages: Array<{ title: string; language: string }>) {
@@ -22,7 +23,7 @@ describe('autoSelectLanguage', () => {
   }
 
   function setUrlSearch(search: string) {
-    (globalThis as any).window = { location: { search } };
+    (globalThis as any).location = { search };
   }
 
   test('should auto-select language from URL parameter when available', () => {
@@ -81,17 +82,5 @@ describe('autoSelectLanguage', () => {
     autoSelectLanguage(service);
 
     expect(service.getCurrentLanguage()).toBe('en');
-  });
-
-  test('should prefer URL parameter over single language fallback', () => {
-    setUrlSearch('?language=de');
-    setLanguages([
-      { title: 'English', language: 'en' },
-      { title: 'Deutsch', language: 'de' },
-    ]);
-
-    autoSelectLanguage(service);
-
-    expect(service.getCurrentLanguage()).toBe('de');
   });
 });

--- a/packages/data/test/load/utils.test.ts
+++ b/packages/data/test/load/utils.test.ts
@@ -1,0 +1,97 @@
+import { expect, test, describe, beforeEach, afterEach } from '@jest/globals';
+import { MemoryStorage } from '../../src/storage';
+import { LanguageService } from '../../src/domain';
+import { autoSelectLanguage } from '../../src/load/utils';
+
+describe('autoSelectLanguage', () => {
+  let memoryStorage: MemoryStorage;
+  let service: LanguageService;
+
+  beforeEach(() => {
+    memoryStorage = new MemoryStorage();
+    service = new LanguageService(memoryStorage);
+    (globalThis as any).window = { location: { search: '' } };
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).window;
+  });
+
+  function setLanguages(languages: Array<{ title: string; language: string }>) {
+    memoryStorage.set('languages', languages);
+  }
+
+  function setUrlSearch(search: string) {
+    (globalThis as any).window = { location: { search } };
+  }
+
+  test('should auto-select language from URL parameter when available', () => {
+    setUrlSearch('?language=de');
+    setLanguages([
+      { title: 'English', language: 'en' },
+      { title: 'Deutsch', language: 'de' },
+    ]);
+
+    autoSelectLanguage(service);
+
+    expect(service.hasLanguage()).toBeTruthy();
+    expect(service.getCurrentLanguage()).toBe('de');
+  });
+
+  test('should not select language from URL parameter when not available', () => {
+    setUrlSearch('?language=fr');
+    setLanguages([
+      { title: 'English', language: 'en' },
+      { title: 'Deutsch', language: 'de' },
+    ]);
+
+    autoSelectLanguage(service);
+
+    expect(service.hasLanguage()).toBeFalsy();
+  });
+
+  test('should auto-select single available language when no URL parameter', () => {
+    setLanguages([{ title: 'English', language: 'en' }]);
+
+    autoSelectLanguage(service);
+
+    expect(service.hasLanguage()).toBeTruthy();
+    expect(service.getCurrentLanguage()).toBe('en');
+  });
+
+  test('should not auto-select when multiple languages and no URL parameter', () => {
+    setLanguages([
+      { title: 'English', language: 'en' },
+      { title: 'Deutsch', language: 'de' },
+    ]);
+
+    autoSelectLanguage(service);
+
+    expect(service.hasLanguage()).toBeFalsy();
+  });
+
+  test('should not change language when already set', () => {
+    setUrlSearch('?language=de');
+    setLanguages([
+      { title: 'English', language: 'en' },
+      { title: 'Deutsch', language: 'de' },
+    ]);
+    service.changeLanguage('en');
+
+    autoSelectLanguage(service);
+
+    expect(service.getCurrentLanguage()).toBe('en');
+  });
+
+  test('should prefer URL parameter over single language fallback', () => {
+    setUrlSearch('?language=de');
+    setLanguages([
+      { title: 'English', language: 'en' },
+      { title: 'Deutsch', language: 'de' },
+    ]);
+
+    autoSelectLanguage(service);
+
+    expect(service.getCurrentLanguage()).toBe('de');
+  });
+});


### PR DESCRIPTION
Check for a `?language=de` URL parameter and auto-select the matching language if available, before falling back to the single-language check. #33 