### PR TITLE
chore: update CI workflow and README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: ci
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build packages
         run: npm run build
 
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
       - name: Run tests
         run: npm test
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@
 | `@smartcompanion/data` | Domain models and data layer — assets, languages, pins, servers, stations, text, tours |
 | `@smartcompanion/services` | Service layer — `AudioPlayerService`, `MenuService`, `RoutingService` |
 
-## Prerequisites
-
-- Node.js >= 14
-- npm >= 7 (workspaces support)
-
 ## Getting Started
 
 ```bash


### PR DESCRIPTION
Exclude tag pushes from ci.yml (handled by release.yml), add Playwright browser install to release.yml, and remove outdated prerequisites from README.