### PR TITLE
fix(ci): isolate test job from publish to avoid clobbered dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,41 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 jobs:
-  release:
+  test:
     runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+  release:
+    needs: test
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,12 +66,6 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      - name: Install Playwright browsers
-        run: npx playwright install chromium
-
-      - name: Run tests
-        run: npm test
-
       - name: Publish all packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -56,7 +78,7 @@ jobs:
             fi
           done
 
-      - name: Add package.json changes to git
+      - name: Commit and push version bump
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           git config user.name "github-actions[bot]"
@@ -70,6 +92,10 @@ jobs:
   storybook:
     needs: release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Split release workflow into test → release → storybook jobs so the release job no longer runs `npm test`. The `stencil-test` binary from @stencil/vitest runs `stencil build --dev` before tests, which overwrote the prod dist produced by the prior build step and left the published tarball missing `dist/esm/`, `dist/cjs/`, `dist/collection/`, `dist/index.{js,cjs.js}`, and
`dist/components/*.js` — the root cause of the broken 0.7.0 publish of @smartcompanion/ui.

Also tightens permissions to least-privilege per job and adds a lint gate to the tag-push pipeline (tags are excluded from ci.yml).