### PR TITLE
feat(data): add share domain for v1.1 schema

### DIFF
--- a/packages/data/src/domain/index.ts
+++ b/packages/data/src/domain/index.ts
@@ -5,3 +5,4 @@ export * from './station';
 export * from './pin';
 export * from './tour';
 export * from './server';
+export * from './share';

--- a/packages/data/src/domain/share/index.ts
+++ b/packages/data/src/domain/share/index.ts
@@ -1,0 +1,2 @@
+export * from './share-service';
+export * from './share-updater';

--- a/packages/data/src/domain/share/share-service.ts
+++ b/packages/data/src/domain/share/share-service.ts
@@ -1,0 +1,20 @@
+import { Storage } from '../../storage';
+
+export class ShareService {
+  protected storage: Storage;
+
+  constructor(storage: Storage) {
+    this.storage = storage;
+  }
+
+  hasShare(): boolean {
+    return this.storage.has('share');
+  }
+
+  getShare(): string {
+    if (this.hasShare()) {
+      return this.storage.get('share') as string;
+    }
+    throw new Error('There is no share defined');
+  }
+}

--- a/packages/data/src/domain/share/share-updater.ts
+++ b/packages/data/src/domain/share/share-updater.ts
@@ -1,0 +1,16 @@
+import { Storage } from '../../storage';
+import { Updater } from '../../update';
+
+export class ShareUpdater implements Updater {
+  protected storage: Storage;
+
+  constructor(storage: Storage) {
+    this.storage = storage;
+  }
+
+  async update(data: unknown) {
+    if (typeof data === 'string') {
+      this.storage.set('share', data);
+    }
+  }
+}

--- a/packages/data/src/service-locator.ts
+++ b/packages/data/src/service-locator.ts
@@ -1,4 +1,4 @@
-import { AssetService, LanguageService, PinService, ServerService, StationService, TextService, TourService, Asset } from './domain';
+import { AssetService, LanguageService, PinService, ServerService, ShareService, StationService, TextService, TourService, Asset } from './domain';
 import { LoadService } from './load';
 import { Storage } from './storage';
 
@@ -23,6 +23,7 @@ export class ServiceLocator {
     this.register(PinService, (serviceLocator: ServiceLocator) => new PinService(serviceLocator.storage));
     this.register(AssetService, (serviceLocator: ServiceLocator) => new AssetService(serviceLocator.storage, resolveUrl));
     this.register(ServerService, (serviceLocator: ServiceLocator) => new ServerService(serviceLocator.storage));
+    this.register(ShareService, (serviceLocator: ServiceLocator) => new ShareService(serviceLocator.storage));
     this.register(TextService, (serviceLocator: ServiceLocator) => new TextService(serviceLocator.storage));
     this.register(StationService, (serviceLocator: ServiceLocator) => new StationService(serviceLocator.storage, serviceLocator.getAssetService()));
     this.register(TourService, (serviceLocator: ServiceLocator) => new TourService(serviceLocator.storage, serviceLocator.getAssetService(), serviceLocator.getStationService()));
@@ -61,6 +62,10 @@ export class ServiceLocator {
 
   getServerService(): ServerService {
     return this.get(ServerService);
+  }
+
+  getShareService(): ShareService {
+    return this.get(ShareService);
   }
 
   getTextService(): TextService {

--- a/packages/data/src/update/data-updater.ts
+++ b/packages/data/src/update/data-updater.ts
@@ -1,7 +1,7 @@
 import { Storage } from '../storage';
 import { Updater } from './updater';
 
-import { AssetUpdater, StationUpdater, LanguageUpdater, TextUpdater, PinUpdater, TourUpdater, ServerUpdater } from '../domain';
+import { AssetUpdater, StationUpdater, LanguageUpdater, TextUpdater, PinUpdater, TourUpdater, ServerUpdater, ShareUpdater } from '../domain';
 
 /**
  * Based on the provided data, updates on the storage are processed.
@@ -22,6 +22,7 @@ export class DataUpdater implements Updater {
     this.registerUpdater('pins', new PinUpdater(this.storage));
     this.registerUpdater('tours', new TourUpdater(this.storage));
     this.registerUpdater('servers', new ServerUpdater(this.storage));
+    this.registerUpdater('share', new ShareUpdater(this.storage));
   }
 
   registerUpdater(name: string, updater: Updater) {

--- a/packages/data/test/domain/share/service.test.ts
+++ b/packages/data/test/domain/share/service.test.ts
@@ -1,0 +1,36 @@
+import { expect, test, describe, beforeEach } from 'vitest';
+import { MemoryStorage } from '../../../src/storage';
+import { ShareService } from '../../../src/domain';
+
+describe('test share service', () => {
+
+  let share = "https://example.com";
+  let memoryStorage = new MemoryStorage();
+  let service = new ShareService(memoryStorage);
+
+  beforeEach(() => {
+    memoryStorage = new MemoryStorage();
+    memoryStorage.set('share', share);
+    service = new ShareService(memoryStorage);
+  });
+
+  test('should return the share url', () => {
+    expect(service.getShare()).toEqual(share);
+  });
+
+  test('should return true if share is in storage', () => {
+    expect(service.hasShare()).toBeTruthy();
+  });
+
+  test('should return false if share is not in storage', () => {
+    const emptyStorage = new MemoryStorage();
+    const emptyService = new ShareService(emptyStorage);
+    expect(emptyService.hasShare()).toBeFalsy();
+  });
+
+  test('should throw if share is not defined', () => {
+    const emptyStorage = new MemoryStorage();
+    const emptyService = new ShareService(emptyStorage);
+    expect(() => emptyService.getShare()).toThrow();
+  });
+});

--- a/packages/data/test/domain/share/updater.test.ts
+++ b/packages/data/test/domain/share/updater.test.ts
@@ -1,0 +1,28 @@
+import { expect, test, describe, beforeEach } from 'vitest';
+import { MemoryStorage } from '../../../src/storage';
+import { ShareUpdater } from '../../../src/domain';
+
+describe('test share updater', () => {
+
+  let memoryStorage = new MemoryStorage();
+  let dataUpdater = new ShareUpdater(memoryStorage);
+
+  beforeEach(() => {
+    memoryStorage = new MemoryStorage();
+    dataUpdater = new ShareUpdater(memoryStorage);
+  });
+
+  test('share should be added to storage', async () => {
+    const share = "https://example.com";
+    await dataUpdater.update(share);
+    expect(memoryStorage.get('share')).toEqual(share);
+  });
+
+  test('adding empty or null data', async () => {
+    await dataUpdater.update(null);
+    await dataUpdater.update(undefined);
+    await dataUpdater.update([]);
+    await dataUpdater.update({});
+    expect(memoryStorage.has('share')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Add ShareService (hasShare/getShare) and ShareUpdater to support the new top-level "share" URL field in the data.json schema. Register the updater in DataUpdater and expose ShareService via ServiceLocator.getShareService().