### PR TITLE
chore(deps): keep majors out of the grouped dependabot sweep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,20 +2,34 @@ version: 2
 
 updates:
   # The root manifest covers every workspace, so one entry keeps all three
-  # packages up to date. Grouped so a routine sweep arrives as one pull request
-  # rather than one per package -- they are built and tested together anyway.
+  # packages up to date.
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
     groups:
+      # Minors and patches only. Grouping majors in here too means a single
+      # incompatible one blocks every other update in the pull request, which
+      # is what happened in #66: TypeScript 7 came bundled with twelve harmless
+      # bumps and took `npm ci` down with it. Majors now arrive as their own
+      # pull requests, so each is assessed -- and fails -- on its own.
       library-dependencies:
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
     ignore:
       # Stencil majors change the component build output and the published
       # entry points, so they need a deliberate migration rather than a bump.
       - dependency-name: '@stencil/core'
+        update-types: [version-update:semver-major]
+
+      # Held back deliberately: @stencil/eslint-plugin declares
+      # `peer typescript@"^4.9.4 || ^5.0.0 || ^6.0.0"`, so TypeScript 7 cannot
+      # resolve against it and `npm ci` fails outright. Drop this rule once the
+      # plugin widens that range.
+      - dependency-name: typescript
         update-types: [version-update:semver-major]
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
## What changed

The first grouped Dependabot run (#66) failed at `npm ci`, before any check ran. Two fixes, both to config introduced in #64.

## Why it failed

Dependabot bundled **`typescript` 5.9.3 → 7.0.2** in with twelve routine bumps. `@stencil/eslint-plugin@1.4.0` declares:

```
peer typescript@"^4.9.4 || ^5.0.0 || ^6.0.0"
```

TypeScript 7 is not in that range, so npm tried to nest `typescript@6.0.3` under the plugin, collided with the root's 7.0.2, and refused to resolve — `Conflicting peer dependency: typescript@6.0.3`.

The update isn't wrong in itself; TypeScript has simply moved ahead of what the Stencil ESLint plugin supports.

## Fix 1 — the group is no longer all-or-nothing

`patterns: ['*']` on its own bundles majors with patches, so one incompatible major blocks everything. In #66 that meant Prettier 3.9.6, ESLint 10.8.0 and Ionic 8.8.15 were all held up by TypeScript — alongside `swiper` 12→14, `dependency-cruiser` 16→18 and `lint-staged` 16→17, each of which deserves its own assessment anyway.

The group is now `update-types: [minor, patch]`. Majors arrive as separate PRs and fail in isolation.

## Fix 2 — TypeScript majors held back

Explicit `ignore` rule with the reason inline, to be dropped once `@stencil/eslint-plugin` widens its peer range.

This is the same class of constraint `native-audio-player` pins `eslint` and `typescript` for. Carrying that config's *shape* into this repo without checking which packages actually cap the toolchain here is what let this through — that was my miss in #64.

## Note

This does not retroactively fix #66. Dependabot will recreate the grouped PR against the new config once this lands; #66 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)