### PR TITLE
chore: check out text files as LF on every platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Check every text file out with LF, on every platform. This mirrors
+# `end_of_line = lf` in .editorconfig, which only editors honour -- git needs
+# telling separately, or a Windows clone gets CRLF in the working tree.
+#
+# That matters here beyond tidiness: Stencil reads component sources from the
+# working tree and embeds their text verbatim into the JSON string values of
+# custom-elements.json. A CRLF checkout therefore produces `\r\n` escapes
+# inside a generated, committed file, which every other contributor's build
+# then flips back -- an endless diff nobody introduced on purpose.
+* text=auto eol=lf
+
+# Binary assets. `text=auto` already detects these, but saying so explicitly
+# keeps a mis-detection from ever corrupting them.
+*.jpeg binary
+*.jpg  binary
+*.png  binary
+*.mp3  binary
+
+# SVG is text despite sitting alongside the images above.
+*.svg text eol=lf
+
+# Generated, committed, and reviewed only for drift -- collapse it by default
+# in GitHub diffs so it stops burying the hand-written changes in a PR.
+package-lock.json linguist-generated=true


### PR DESCRIPTION
## What changed

Adds a `.gitattributes` that checks every text file out as LF on all platforms, marks image/audio assets as binary explicitly, and collapses `package-lock.json` in GitHub diffs.

`.editorconfig` already declares `end_of_line = lf`, but only editors honour that — git needs telling separately, so a Windows clone still gets CRLF in the working tree.

That has a concrete cost here beyond tidiness. Stencil reads component sources from the *working tree* and embeds their text verbatim into the JSON string values of `custom-elements.json`, which is generated and committed:

```json
"declaration": "export type PageErrorFacade = Translator & {\n  getMenuService(): Menu;\n ..."
```

A CRLF checkout therefore writes `\r\n` escapes into that file, and the next contributor's build flips them straight back — churn nobody introduced on purpose, in a file that's otherwise reviewed only for prop drift. This showed up for real in #78, where 29 such escapes appeared in the `typeLibrary` block.

`package-lock.json` is marked `linguist-generated=true` so it collapses by default in diffs. `custom-elements.json` and `components.d.ts` are deliberately **not** marked — drift in those is something we want to notice, and #78 is the example of why.

## Verification

- **No renormalization:** `git add --renormalize .` is a no-op across the tree — no tracked file currently holds CRLF bytes, so this changes nothing that already exists.
- **Binaries safe:** a fresh worktree checkout is byte-identical to the working copy across all 295 tracked files, jpegs/mp3s/pngs included. (`text=auto` detects them anyway; the explicit `binary` lines are belt-and-braces against a mis-detection.)
- Lint, `format:check`, `depcruise`, and the full test suite all pass locally.

## Packages touched

- [ ] `@smartcompanion/data`
- [ ] `@smartcompanion/services`
- [ ] `@smartcompanion/ui`

Repo tooling only.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run depcruise` passes — no new dependency between packages
- [x] `npm test` passes
- [x] A changeset is included (`npm run changeset`), unless this changes nothing that gets published — n/a, nothing published changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
