### PR TITLE
docs: add a README to each package, and make the root README useful to consumers

### DIFF
--- a/.changeset/lucky-moons-shave.md
+++ b/.changeset/lucky-moons-shave.md
@@ -1,0 +1,8 @@
+---
+'@smartcompanion/ui': patch
+---
+
+Add a README to each package, and the `description`, `keywords`, `homepage`
+and `bugs` fields npm renders alongside it. `services` and `ui` had no README
+at all, so their npm pages showed nothing about what the package is or how to
+install it, and none of the three declared a description.

--- a/.changeset/quiet-ravens-look.md
+++ b/.changeset/quiet-ravens-look.md
@@ -1,0 +1,15 @@
+---
+'@smartcompanion/data': patch
+'@smartcompanion/services': patch
+---
+
+Document an API removal that shipped undocumented in 0.10.0.
+
+[#63](https://github.com/smartcompanion-app/smartcompanion-library/pull/63) removed `ServiceLocator` from `@smartcompanion/data` and `ServiceFacade.registerDefaultServices()` from `@smartcompanion/services`, replacing the service-locator indirection with direct accessors on the facade and narrow role contracts (`StationListFacade` and friends) on the UI pages. It went out in 0.10.0 without a changeset, so the changelog for that release does not mention it — code calling `registerDefaultServices()` fails on upgrade with nothing to explain why. Nothing changes in this release; this entry exists so the removal is on the record.
+
+To migrate from 0.9.x:
+
+- Delete the `registerDefaultServices()` call. The domain services, routing and menu are available directly from the facade — `getStationService()`, `getRoutingService()`, `getMenuService()` and the rest — with no registration step.
+- If you passed a custom `resolveUrl` to it, pass it as the second constructor argument instead: `new ServiceFacade(storage, resolveUrl)`. The signature and the default are unchanged.
+- Registering an audio player and a load service is still required, and still works exactly as before.
+- Imports of `ServiceLocator` from `@smartcompanion/data` need removing. UI page components now declare the narrow contract they need rather than taking a locator.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 ![License](https://img.shields.io/github/license/smartcompanion-app/smartcompanion-library)
 [![Storybook](https://img.shields.io/badge/Storybook-UI%20Components-ff4785)](https://smartcompanion-app.github.io/smartcompanion-library/)
 
+The building blocks behind the SmartCompanion audio-guide apps: the data layer, the services that drive it, and the web components users actually see. Published as three npm packages, versioned in lockstep.
+
 ## Table of Contents
 
 - [Packages](#packages)
+- [Using the Packages](#using-the-packages)
 - [Getting Started](#getting-started)
 - [Local Development](#local-development)
 - [Contributing](#contributing)
@@ -18,11 +21,45 @@
 
 | Package | Description |
 | --- | --- |
-| `@smartcompanion/ui` | Stencil v4 web components — `image-slideshow`, `marquee`, `numpad`, `player-controls`, `station-icon` |
-| `@smartcompanion/data` | Domain models and data layer — assets, languages, pins, servers, stations, text, tours |
-| `@smartcompanion/services` | Service layer — `AudioPlayerService`, `MenuService`, `RoutingService` |
+| [`@smartcompanion/ui`](https://www.npmjs.com/package/@smartcompanion/ui) [![npm](https://img.shields.io/npm/v/@smartcompanion/ui)](https://www.npmjs.com/package/@smartcompanion/ui) | Stencil v4 web components — five building blocks (`sc-image-slideshow`, `sc-marquee`, `sc-numpad`, `sc-player-controls`, `sc-station-icon`) and thirteen ready-made `sc-page-*` pages |
+| [`@smartcompanion/data`](https://www.npmjs.com/package/@smartcompanion/data) [![npm](https://img.shields.io/npm/v/@smartcompanion/data)](https://www.npmjs.com/package/@smartcompanion/data) | Domain models and data layer — assets, languages, pins, servers, stations, text, tours, plus storage, loading and updates |
+| [`@smartcompanion/services`](https://www.npmjs.com/package/@smartcompanion/services) [![npm](https://img.shields.io/npm/v/@smartcompanion/services)](https://www.npmjs.com/package/@smartcompanion/services) | Service layer — `ServiceFacade` over the data layer, plus `AudioPlayerService`, `MenuService`, `RoutingService` |
+
+Each package has its own README with installation details and usage: [ui](packages/ui/README.md) · [data](packages/data/README.md) · [services](packages/services/README.md).
+
+## Using the Packages
+
+Building an app *with* the library, rather than working on the library itself:
+
+```bash
+npm install @smartcompanion/ui @smartcompanion/services @smartcompanion/data
+```
+
+Importing `@smartcompanion/ui` registers every custom element; pages take a `ServiceFacade` as their `facade` prop.
+
+```ts
+import '@smartcompanion/ui';
+import { ServiceFacade } from '@smartcompanion/services';
+
+const facade = new ServiceFacade();
+facade.registerCollectibleAudioPlayerService('My Audio Guide');
+facade.registerOnlineLoadService(() => fetch('/data.json').then(r => r.json()));
+```
+
+```tsx
+<sc-page-stations facade={facade} />
+```
+
+Two constraints worth knowing before you start:
+
+- **Node 20 or newer**, and `@smartcompanion/services` expects `@capacitor/core`, `@ionic/core` and `@smartcompanion/native-audio-player` as peers alongside `@smartcompanion/data`.
+- **`data` and `services` are ESM-only.** They declare `"type": "module"` and ship an `exports` map, so `import` works from Node and from bundlers, but `require()` is not supported. `ui` is unaffected — Stencil emits its own CommonJS, ESM and custom-elements builds.
+
+The [audioguide app](https://github.com/smartcompanion-app/audioguide-app) is a complete worked example.
 
 ## Getting Started
+
+Working on the library itself:
 
 ```bash
 npm install        # Install all workspace dependencies

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,13 +1,46 @@
-# Smartcompanion Data
+# @smartcompanion/data
 
-## Callbacks
+Domain models and the data layer behind the SmartCompanion apps: tours, stations, assets, languages, text, pins and servers, plus the storage, loading and update machinery that keeps them in sync.
 
- - `downloadData`: Download data and return parsed json
- - `downloadFile`: Download asset file and return blob
- - `remove`: Remove file with filename from filesystem
- - `save`: Store blob locally
- - `list`: List all local files
+Part of the [SmartCompanion Library](https://github.com/smartcompanion-app/smartcompanion-library) monorepo. `@smartcompanion/services` and `@smartcompanion/ui` are built on top of it.
 
-## JSON Schema
+## Install
 
-Open [JSON-Editor](https://json-editor.github.io/json-editor/) and copy schema file to get form.
+```bash
+npm install @smartcompanion/data
+```
+
+Requires Node 20 or newer.
+
+> **ESM only.** This package declares `"type": "module"` and ships an `exports` map. `import` works from Node and from bundlers; `require()` is not supported.
+
+## What's in it
+
+| Area | Contents |
+| --- | --- |
+| Domain | `AssetService`, `LanguageService`, `PinService`, `ServerService`, `ShareService`, `StationService`, `TextService`, `TourService` — each with a matching updater |
+| Storage | `Storage` interface with `BrowserStorage` and `MemoryStorage` implementations |
+| Loading | `LoadService`, `OnlineLoadService`, `OfflineLoadService` |
+| Updating | `Updater`, `DataUpdater` |
+
+Most applications will not construct these directly — [`@smartcompanion/services`](https://www.npmjs.com/package/@smartcompanion/services) wires them together behind a single `ServiceFacade`.
+
+## Offline callbacks
+
+`OfflineLoadService` is driven by five callbacks, supplied by the host application because the filesystem differs per platform:
+
+| Callback | Responsibility |
+| --- | --- |
+| `downloadData` | Download data and return parsed JSON |
+| `downloadFile` | Download an asset file and return a blob |
+| `remove` | Remove a file by filename from the filesystem |
+| `save` | Store a blob locally |
+| `list` | List all local files |
+
+## Data format
+
+The JSON schema describing the tour data format lives in the [data-format](https://github.com/smartcompanion-app/data-format) repository. To explore it as a form, open [JSON-Editor](https://json-editor.github.io/json-editor/) and paste the schema in.
+
+## License
+
+BSD-2-Clause. See [LICENSE](https://github.com/smartcompanion-app/smartcompanion-library/blob/main/LICENSE).

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,20 @@
 {
   "name": "@smartcompanion/data",
+  "description": "Domain models and data layer for SmartCompanion apps — tours, stations, assets, languages, storage, loading and updates.",
   "version": "0.10.0",
+  "keywords": [
+    "smartcompanion",
+    "audioguide",
+    "museum",
+    "tours",
+    "stations",
+    "offline",
+    "data-layer"
+  ],
+  "homepage": "https://github.com/smartcompanion-app/smartcompanion-library/tree/main/packages/data#readme",
+  "bugs": {
+    "url": "https://github.com/smartcompanion-app/smartcompanion-library/issues"
+  },
   "author": "SmartCompanion Team <hello@smartcompanion.app> (https://smartcompanion.app) ",
   "repository": {
     "type": "git",

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -1,0 +1,56 @@
+# @smartcompanion/services
+
+The service layer for SmartCompanion apps. `ServiceFacade` assembles the domain services from [`@smartcompanion/data`](https://www.npmjs.com/package/@smartcompanion/data) and adds audio playback, menu state and routing, so an application wires up one object instead of a dozen.
+
+Part of the [SmartCompanion Library](https://github.com/smartcompanion-app/smartcompanion-library) monorepo.
+
+## Install
+
+```bash
+npm install @smartcompanion/services
+```
+
+Requires Node 20 or newer, and these peers:
+
+```
+@smartcompanion/data                >=0.9.0
+@smartcompanion/native-audio-player ^0.5.0
+@capacitor/core                     ^8.3.1
+@ionic/core                         ^8.7.2
+```
+
+> **ESM only.** This package declares `"type": "module"` and ships an `exports` map. `import` works from Node and from bundlers; `require()` is not supported.
+
+## Usage
+
+Create the facade, choose an audio player, and choose how data is loaded:
+
+```ts
+import { ServiceFacade } from '@smartcompanion/services';
+
+const facade = new ServiceFacade();
+
+// Collectible tracks progress per station; the default player does not.
+facade.registerCollectibleAudioPlayerService('My Audio Guide');
+
+facade.registerOnlineLoadService(() =>
+  fetch('https://example.com/data.json', { cache: 'no-store' }).then(r => r.json()),
+);
+```
+
+For an offline-capable app, register `registerOfflineLoadService` instead and supply the five filesystem callbacks documented in [`@smartcompanion/data`](https://www.npmjs.com/package/@smartcompanion/data).
+
+The facade is then handed to the page components from [`@smartcompanion/ui`](https://www.npmjs.com/package/@smartcompanion/ui) as their `facade` prop.
+
+## What it exposes
+
+- **Accessors** — `getStationService()`, `getTourService()`, `getAssetService()`, `getTextService()`, `getLanguageService()`, `getPinService()`, `getServerService()`, `getShareService()`, `getStorage()`
+- **App services** — `getAudioPlayerService()`, `getMenuService()`, `getRoutingService()`, `getLoadService()`
+- **Language** — `changeLanguage()`, `getLanguages()`
+- **Routing guards** — `canLoadRoute()`, `getPendingRoute()`
+
+`AudioPlayerService`, `MenuService` and `RoutingService` are also exported directly if you need them outside the facade.
+
+## License
+
+BSD-2-Clause. See [LICENSE](https://github.com/smartcompanion-app/smartcompanion-library/blob/main/LICENSE).

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,21 @@
 {
   "name": "@smartcompanion/services",
+  "description": "Service layer for SmartCompanion apps — ServiceFacade over the data layer, plus audio playback, menu and routing.",
   "version": "0.10.0",
+  "keywords": [
+    "smartcompanion",
+    "audioguide",
+    "museum",
+    "services",
+    "audio-player",
+    "routing",
+    "ionic",
+    "capacitor"
+  ],
+  "homepage": "https://github.com/smartcompanion-app/smartcompanion-library/tree/main/packages/services#readme",
+  "bugs": {
+    "url": "https://github.com/smartcompanion-app/smartcompanion-library/issues"
+  },
   "author": "SmartCompanion Team <hello@smartcompanion.app> (https://smartcompanion.app) ",
   "repository": {
     "type": "git",

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,51 @@
+# @smartcompanion/ui
+
+The web components behind the SmartCompanion audio-guide apps — built with [Stencil](https://stenciljs.com/), so they work in any framework or none. Five building-block components and thirteen ready-made pages, from the station list to the map.
+
+Part of the [SmartCompanion Library](https://github.com/smartcompanion-app/smartcompanion-library) monorepo.
+
+**[Browse the components in Storybook →](https://smartcompanion-app.github.io/smartcompanion-library/)**
+
+## Install
+
+```bash
+npm install @smartcompanion/ui
+```
+
+Requires Node 20 or newer, and [`@smartcompanion/data`](https://www.npmjs.com/package/@smartcompanion/data) `>=0.9.0` as a peer. Pages are driven by a `ServiceFacade` from [`@smartcompanion/services`](https://www.npmjs.com/package/@smartcompanion/services).
+
+## Usage
+
+Importing the package registers every custom element:
+
+```ts
+import '@smartcompanion/ui';
+```
+
+Pages take the service facade as a prop:
+
+```tsx
+<sc-page-stations facade={serviceFacade} />
+```
+
+In a Stencil app that is typically passed via `componentProps` on the router route. `defineCustomElements` is also available from `@smartcompanion/ui/loader` if you need to control registration yourself.
+
+## Components
+
+Building blocks:
+
+`sc-image-slideshow` · `sc-marquee` · `sc-numpad` · `sc-player-controls` · `sc-station-icon`
+
+Pages:
+
+`sc-page-error` · `sc-page-language` · `sc-page-loading` · `sc-page-map` · `sc-page-multi-audio-station` · `sc-page-pin` · `sc-page-selection` · `sc-page-station` · `sc-page-station-image-list` · `sc-page-station-list` · `sc-page-stations` · `sc-page-tabbed-station-list` · `sc-page-tour-list`
+
+Props and events for each are documented in [Storybook](https://smartcompanion-app.github.io/smartcompanion-library/).
+
+## Maps
+
+`sc-page-map` renders with [MapLibre GL](https://maplibre.org/). Give it either `mapStyleUrl` for vector tiles or `tileUrlTemplate` for a raster `{z}/{y}/{x}` template — exactly one of the two is required.
+
+## License
+
+BSD-2-Clause. See [LICENSE](https://github.com/smartcompanion-app/smartcompanion-library/blob/main/LICENSE).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,20 @@
 {
   "name": "@smartcompanion/ui",
+  "description": "Stencil web components for SmartCompanion audio-guide apps — station lists, player controls, maps and more.",
   "version": "0.10.0",
+  "keywords": [
+    "smartcompanion",
+    "audioguide",
+    "museum",
+    "stencil",
+    "web-components",
+    "ionic",
+    "maplibre"
+  ],
+  "homepage": "https://github.com/smartcompanion-app/smartcompanion-library/tree/main/packages/ui#readme",
+  "bugs": {
+    "url": "https://github.com/smartcompanion-app/smartcompanion-library/issues"
+  },
   "author": "SmartCompanion Team <hello@smartcompanion.app> (https://smartcompanion.app) ",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed

Documentation only — no source changes.

`services` and `ui` had **no README at all**, so their npm pages showed nothing about what the package is or how to install it. `data` had thirteen lines that opened on a list of offline callbacks without ever saying what the package does, and pointed at a schema file that is not in the package. None of the three declared a `description` or `keywords`, both of which npm renders on the package page and uses for search.

### Per-package READMEs

Each now covers the same ground: what the package is, how to install it, what it requires, and a short usage example.

- Peer dependencies are spelled out for `services`, which needs four of them.
- The **ESM-only** constraint is stated for `data` and `services`, since `require()` failing is something consumers actually hit.
- The `ui` README points at Storybook rather than duplicating prop tables that would drift.

### npm metadata

Added `description`, `keywords`, `homepage` and `bugs` to all three `package.json` files.

### Root README

It was written entirely for contributors — "Getting Started" was `npm install` for the monorepo, and a reader arriving from npm learned nothing about consuming the library. Adds a **Using the Packages** section with an install line, a worked example, and the constraints people hit first (Node 20, the peers, ESM-only).

It also corrects the packages table, which advertised **five** components. There are eighteen: the five building blocks it listed, plus the thirteen `sc-page-*` pages that are the bulk of the library. Rows now link to npm with version badges.

## Verification

- Examples are taken from how [audioguide-app](https://github.com/smartcompanion-app/audioguide-app) actually wires the library up, not invented. This is how I caught that `registerDefaultServices()` — the natural thing to write — was removed in #63 and no longer exists.
- Every referenced API checked against source: `ServiceFacade` methods, and `facade` props on the page components.
- All relative links resolve; the three npm version badges return HTTP 200.
- READMEs confirmed present in all three packed tarballs (npm includes them regardless of `files`).
- `lint`, `format:check`, `check:publish` (3/3) and the full test suite pass.

## Noted separately

While verifying the examples I found that **`ServiceFacade.registerDefaultServices()` and `ServiceLocator` were removed in #63 and shipped in 0.10.0 with no changeset** — the changelog covers ESM, swiper and engines, but not the facade API. `audioguide-app` still calls that method and only works because it pins `^0.9.0`. Not fixed here; it needs its own changeset documenting the removal and migration.

## Packages touched

- [x] `@smartcompanion/data`
- [x] `@smartcompanion/services`
- [x] `@smartcompanion/ui`

Documentation and package metadata only.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run depcruise` passes — no new dependency between packages
- [x] `npm test` passes
- [x] A changeset is included (`npm run changeset`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
