### PR TITLE
test(ui): cover sc-page-map in a real browser

### DIFF
--- a/packages/ui/src/pages/page-map/page-map.browser.tsx
+++ b/packages/ui/src/pages/page-map/page-map.browser.tsx
@@ -1,0 +1,90 @@
+import { render, h, describe, it, expect } from '@stencil/vitest';
+import { Menu, Router, StationListFacade, StationSource, TourSource } from '../../contracts';
+import { Station } from '@smartcompanion/data';
+
+// The map box the storybook example uses, around the same tiles.
+const mapBounds = [47.58308, 12.166456, 47.578141, 12.171476];
+
+const stations: Station[] = [
+  { id: 'a', number: '1', latitude: 47.5805, longitude: 12.1685 } as Station,
+  { id: 'b', number: '2', latitude: 47.5812, longitude: 12.1695 } as Station,
+  // No coordinates: belongs to the tour, but cannot be placed on the map.
+  { id: 'c', number: '3' } as Station,
+];
+
+const createFacade = (pushed: string[], tourStations: Station[] = stations) =>
+  ({
+    getMenuService: () =>
+      ({
+        enable: () => Promise.resolve(),
+      }) as Menu,
+    getStationService: () =>
+      ({
+        getStations: () => Promise.resolve(stations),
+      }) as StationSource,
+    getTourService: () =>
+      ({
+        getStations: (_tourId: string) => Promise.resolve(tourStations),
+      }) as TourSource,
+    getRoutingService: () =>
+      ({
+        push: (uri: string) => {
+          pushed.push(uri);
+          return Promise.resolve();
+        },
+      }) as Router,
+    __: (key: string) => key,
+  }) as StationListFacade;
+
+const markers = (root: HTMLElement) => Array.from(root.querySelectorAll('.station-map-marker')) as HTMLElement[];
+
+const renderMap = async (facade: StationListFacade, tourId?: string) => {
+  const result = await render(
+    <sc-page-map mapBounds={mapBounds} tileUrlTemplate="map-assets/{z}/{y}/{x}.jpeg" mapAttribution="&copy; basemap.at" facade={facade} tourId={tourId} />,
+  );
+  await result.waitForChanges();
+  // Markers are attached once the station list resolves, one microtask after
+  // componentDidLoad kicks off stationMarkers().
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await result.waitForChanges();
+  return result;
+};
+
+describe('sc-page-map', () => {
+  it('initialises a real maplibre map', async () => {
+    const { root } = await renderMap(createFacade([]));
+
+    // A WebGL canvas is the thing mock-doc could never produce, and the reason
+    // this page had no rendering test at all before.
+    expect(root.querySelector('canvas.maplibregl-canvas')).not.toBeNull();
+  });
+
+  it('places one marker per station that has coordinates', async () => {
+    const { root } = await renderMap(createFacade([]));
+
+    const placed = markers(root);
+    expect(placed).toHaveLength(2);
+    expect(placed.map(marker => marker.textContent.trim())).toEqual(['1', '2']);
+  });
+
+  it('opens the station a marker belongs to when it is clicked', async () => {
+    const pushed: string[] = [];
+    const { root } = await renderMap(createFacade(pushed));
+
+    markers(root)[1].click();
+
+    expect(pushed).toEqual(['/stations/b']);
+  });
+
+  it('keeps the tour in the route when the map is scoped to one', async () => {
+    const pushed: string[] = [];
+    const { root } = await renderMap(createFacade(pushed, [stations[0]]), 'tour-7');
+
+    const placed = markers(root);
+    expect(placed).toHaveLength(1);
+
+    placed[0].click();
+
+    expect(pushed).toEqual(['/tours/tour-7/stations/a']);
+  });
+});


### PR DESCRIPTION
## What changed

Adds `page-map.browser.tsx`. Test-only — no source changes, so no changeset.

`sc-page-map` was the **only component in the library with no rendering test**. Its leaflet snapshot was deleted in #78 — correctly, since it recorded leaflet's DOM down to `.leaflet-pane` class names — and replaced with unit tests for the extracted helpers. Those cover the pure functions well, but leave the component itself untested: nothing exercised marker placement, or what happens when one is clicked.

mock-doc cannot host maplibre, which needs WebGL. So this goes in the `browser` project, where Playwright runs real Chromium.

## Cases

| Test | What it pins down |
| --- | --- |
| initialises a real maplibre map | A `canvas.maplibregl-canvas` exists — the thing mock-doc could never produce, and the reason this page had no rendering test |
| places one marker per station that has coordinates | Two markers for three stations; the one without coordinates is skipped, and the markers carry the right station numbers |
| opens the station a marker belongs to when clicked | Clicking the second marker routes to `/stations/b` |
| keeps the tour in the route when scoped to one | With `tourId`, routes to `/tours/tour-7/stations/a` |

Follows the conventions already in the browser tests — plain recorder functions rather than `vi.fn()`, and contract objects rather than full service instances.

## These tests actually fail when the behaviour breaks

Verified rather than assumed, since a test that renders a map and asserts nothing useful is worse than no test:

- Removing the `openStation` call from the marker click handler → **both routing tests fail**.
- Renaming the marker class from `station-map-marker`, which is exactly the breaking change #78 shipped → **four tests fail** across this file and the helper spec.

Both mutations were reverted; the diff is the new file only.

## Verification

`lint`, `format:check`, `depcruise` (148 modules) and the full suite pass — ui goes from 93 to 97 tests, 30 files passing.

## Packages touched

- [ ] `@smartcompanion/data`
- [ ] `@smartcompanion/services`
- [x] `@smartcompanion/ui`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run depcruise` passes — no new dependency between packages
- [x] `npm test` passes
- [x] A changeset is included (`npm run changeset`), unless this changes nothing that gets published — tests only, nothing published changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
