### PR TITLE
chore(services): move to native-audio-player 1.0

### DIFF
--- a/.changeset/olive-pans-search.md
+++ b/.changeset/olive-pans-search.md
@@ -12,18 +12,17 @@ The plugin renamed its player event from `update` to `audioPlayerChange`, and
 `registerUpdateListener` still reports exactly what it did before, and nothing
 in this package's own API changes.
 
-Two behaviour changes come from the plugin itself and are worth knowing about,
-since they are visible to an app without it calling anything:
+Three behaviour changes come from the plugin itself and are worth knowing
+about, since an app sees them without calling anything:
 
 - **iOS now starts on the speaker** rather than the earpiece, matching Android.
   An app that relied on the earpiece default has to call `setEarpiece()` after
   `start()` to keep it.
-- **Playback the system stops** — an incoming call, Siri, another app taking
-  the audio — is now reported as `paused`, where previously it stopped silently
-  and left an app's own UI showing the wrong control.
-
-`getPosition()` and `getDuration()` also report fractional seconds on every
-platform now, rather than truncating to whole seconds on iOS and Android. Both
-still return a `number`, and `formatSeconds` in `@smartcompanion/ui` already
-truncates, so displayed times are unaffected; a progress bar simply moves
-smoothly on the two platforms where it previously stepped.
+- **Playback stopped by the system** — an incoming call, Siri, or another app
+  taking the audio — is now reported as `paused`. Previously it stopped
+  silently, leaving an app's own UI showing the wrong control.
+- **`getPosition()` and `getDuration()` report fractional seconds** on every
+  platform, rather than truncating to whole seconds on iOS and Android. Both
+  still return a `number`, and `formatSeconds` in `@smartcompanion/ui` already
+  truncates, so displayed times are unaffected; a progress bar simply moves
+  smoothly on the two platforms where it previously stepped.

--- a/.changeset/olive-pans-search.md
+++ b/.changeset/olive-pans-search.md
@@ -1,0 +1,29 @@
+---
+'@smartcompanion/services': minor
+---
+
+Move to `@smartcompanion/native-audio-player` 1.0, its first stable release.
+The peer range is now `^1.0.0`; 0.5.x is no longer accepted, so an app has to
+upgrade the plugin alongside this package.
+
+The plugin renamed its player event from `update` to `audioPlayerChange`, and
+`AudioPlayerService` follows. The payload is unchanged — the same `state` of
+`playing`, `paused`, `skip` or `completed`, and the same `id` — so
+`registerUpdateListener` still reports exactly what it did before, and nothing
+in this package's own API changes.
+
+Two behaviour changes come from the plugin itself and are worth knowing about,
+since they are visible to an app without it calling anything:
+
+- **iOS now starts on the speaker** rather than the earpiece, matching Android.
+  An app that relied on the earpiece default has to call `setEarpiece()` after
+  `start()` to keep it.
+- **Playback the system stops** — an incoming call, Siri, another app taking
+  the audio — is now reported as `paused`, where previously it stopped silently
+  and left an app's own UI showing the wrong control.
+
+`getPosition()` and `getDuration()` also report fractional seconds on every
+platform now, rather than truncating to whole seconds on iOS and Android. Both
+still return a `number`, and `formatSeconds` in `@smartcompanion/ui` already
+truncates, so displayed times are unaffected; a progress bar simply moves
+smoothly on the two platforms where it previously stepped.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3235,16 +3235,6 @@
       "resolved": "packages/data",
       "link": true
     },
-    "node_modules/@smartcompanion/native-audio-player": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@smartcompanion/native-audio-player/-/native-audio-player-0.5.0.tgz",
-      "integrity": "sha512-jkbhzTtCSjwcrq5zmlV1jNeaf20vS3sam1LHvCe29wzCYWvLOVXdT0OS9U95l2FawWugv1wfz/jO+YCEtRiZVQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
-      }
-    },
     "node_modules/@smartcompanion/services": {
       "resolved": "packages/services",
       "link": true
@@ -11615,7 +11605,7 @@
         "@capacitor/core": "^8.5.0",
         "@ionic/core": "^8.8.16",
         "@smartcompanion/data": "^0.10.0",
-        "@smartcompanion/native-audio-player": "^0.5.0"
+        "@smartcompanion/native-audio-player": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -11624,7 +11614,17 @@
         "@capacitor/core": "^8.3.1",
         "@ionic/core": "^8.7.2",
         "@smartcompanion/data": ">=0.9.0",
-        "@smartcompanion/native-audio-player": "^0.5.0"
+        "@smartcompanion/native-audio-player": "^1.0.0"
+      }
+    },
+    "packages/services/node_modules/@smartcompanion/native-audio-player": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smartcompanion/native-audio-player/-/native-audio-player-1.0.0.tgz",
+      "integrity": "sha512-lctPEThpUmWKnJYbY23q3bW6O5gHorK5EgF1y+/KVn9a4V5paZkgG0CunjuCMS1L/vctbhe86zQRFiMzHOpw/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "packages/ui": {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -57,12 +57,12 @@
     "@capacitor/core": "^8.3.1",
     "@ionic/core": "^8.7.2",
     "@smartcompanion/data": ">=0.9.0",
-    "@smartcompanion/native-audio-player": "^0.5.0"
+    "@smartcompanion/native-audio-player": "^1.0.0"
   },
   "devDependencies": {
     "@capacitor/core": "^8.5.0",
     "@ionic/core": "^8.8.16",
     "@smartcompanion/data": "^0.10.0",
-    "@smartcompanion/native-audio-player": "^0.5.0"
+    "@smartcompanion/native-audio-player": "^1.0.0"
   }
 }

--- a/packages/services/src/services/audio-player-service/audio-player-service.ts
+++ b/packages/services/src/services/audio-player-service/audio-player-service.ts
@@ -52,7 +52,7 @@ export class AudioPlayerService {
   }
 
   async registerUpdateListener(callback: (update: AudioPlayerUpdate) => void) {
-    this.updateListenerHandle = await NativeAudioPlayer.addListener('update', async result => {
+    this.updateListenerHandle = await NativeAudioPlayer.addListener('audioPlayerChange', async result => {
       callback({
         state: result.state,
         id: result.id,

--- a/packages/ui/custom-elements.json
+++ b/packages/ui/custom-elements.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-08-08T09:35:49",
+  "timestamp": "2026-08-07T06:45:58",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.43.5",

--- a/packages/ui/custom-elements.json
+++ b/packages/ui/custom-elements.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-08-07T06:45:58",
+  "timestamp": "2026-08-08T09:35:49",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.43.5",


### PR DESCRIPTION
## What changed

Moves `@smartcompanion/native-audio-player` to **1.0.0**, its first stable release. Peer and dev ranges go to `^1.0.0`; 0.5.x is no longer accepted, so an app has to upgrade the plugin alongside this package.

## The one code change

The plugin renamed its player event, and `AudioPlayerService` follows:

```diff
- NativeAudioPlayer.addListener('update', ...)
+ NativeAudioPlayer.addListener('audioPlayerChange', ...)
```

The release notes say *"nothing in this release breaks an app that was working against 0.5.0"* while also listing that rename, so I checked rather than trusted it — diffing the published type definitions:

```
0.5.0  addListener(eventName: 'update', ...)
1.0.0  addListener(eventName: 'audioPlayerChange', ...)   ← no 'update' overload
```

The `update` overload is simply gone. Building against v1 with the old name fails with `TS2769: No overload matches this call`, so this could not have shipped silently broken — but nothing in the test suite covers the event name, so the compiler is the only thing catching it.

The payload is identical: same `state` union (`playing`/`paused`/`skip`/`completed`), same `id`. `registerUpdateListener` reports exactly what it did before, and this package's own API is unchanged.

## Plugin behaviour an app will notice

Documented in the changeset, because these happen without an app calling anything:

- **iOS now starts on the speaker**, not the earpiece, matching Android. An app relying on the earpiece default must call `setEarpiece()` after `start()`.
- **System interruptions** — a call, Siri, another app taking audio — are now reported as `paused` instead of stopping silently and desyncing the UI.
- **Positions and durations are fractional seconds** on every platform. Both still return `number`, and `formatSeconds` in `@smartcompanion/ui` already truncates, so displayed times are unaffected; progress bars simply move smoothly where they previously stepped.

## Verification

`build`, `lint`, `format:check`, `depcruise`, `check:publish` (3/3) and the full suite — 103 + 15 + 97 passing.

## Packages touched

- [ ] `@smartcompanion/data`
- [x] `@smartcompanion/services`
- [ ] `@smartcompanion/ui`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run depcruise` passes
- [x] `npm test` passes
- [x] A changeset is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
