### PR TITLE
chore(ui): update maplibre-gl to 6

### DIFF
--- a/.changeset/brave-jokes-melt.md
+++ b/.changeset/brave-jokes-melt.md
@@ -1,0 +1,18 @@
+---
+'@smartcompanion/ui': minor
+---
+
+Update the bundled map renderer to maplibre-gl 6. `sc-page-map` behaves
+exactly as before — same props, same markers, same attribution and the same
+disabled rotation — but apps that bundle this package now pull maplibre 6
+instead of 5.
+
+maplibre 6 removed its default export, so the component imports `Map`,
+`Marker` and `AttributionControl` by name. This is internal; nothing in the
+component's own API changes.
+
+The stylesheet is now imported as `~maplibre-gl/dist/maplibre-gl.css`, the same
+form the station list already uses for swiper, rather than by a relative path
+into the repository root's `node_modules`. npm places maplibre 6 under
+`packages/ui/node_modules` rather than hoisting it, which the hard-coded path
+could not follow.

--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -42,6 +42,10 @@
   ],
   "options": {
     "doNotFollow": { "path": "node_modules" },
-    "tsPreCompilationDeps": true
+    "tsPreCompilationDeps": true,
+    "enhancedResolveOptions": {
+      "conditionNames": ["import", "require", "node", "default", "types"],
+      "mainFields": ["module", "main", "types"]
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1562,32 +1562,6 @@
       "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@mapbox/vector-tile": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
-      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@mapbox/point-geometry": "~1.1.0",
-        "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.2"
-      }
-    },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@maplibre/geojson-vt": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
@@ -1596,31 +1570,6 @@
       "dependencies": {
         "kdbush": "^4.1.0"
       }
-    },
-    "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
-      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^1.0.0",
-        "json-stringify-pretty-compact": "^4.0.0",
-        "minimist": "^1.2.8",
-        "quickselect": "^3.0.0",
-        "tinyqueue": "^3.0.0"
-      },
-      "bin": {
-        "gl-style-format": "dist/gl-style-format.mjs",
-        "gl-style-migrate": "dist/gl-style-migrate.mjs",
-        "gl-style-validate": "dist/gl-style-validate.mjs"
-      }
-    },
-    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
-      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/@maplibre/mlt": {
       "version": "1.1.12",
@@ -7669,40 +7618,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/maplibre-gl": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
-      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.1.0",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/geojson-vt": "^6.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
-        "@maplibre/mlt": "^1.1.8",
-        "@maplibre/vt-pbf": "^4.3.0",
-        "@types/geojson": "^7946.0.16",
-        "earcut": "^3.0.2",
-        "gl-matrix": "^3.4.4",
-        "kdbush": "^4.0.2",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
-        "potpack": "^2.1.0",
-        "quickselect": "^3.0.0",
-        "tinyqueue": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.14.0",
-        "npm": ">=8.1.0"
-      },
-      "funding": {
-        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
-      }
-    },
     "node_modules/marked": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
@@ -8484,18 +8399,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
-      }
-    },
-    "node_modules/pbf": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
-      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "resolve-protobuf-schema": "^2.1.0"
-      },
-      "bin": {
-        "pbf": "bin/pbf"
       }
     },
     "node_modules/picocolors": {
@@ -11447,7 +11350,7 @@
       "version": "0.10.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "maplibre-gl": "^5.24.0",
+        "maplibre-gl": "^6.2.0",
         "swiper": "^14.1.0"
       },
       "devDependencies": {
@@ -11465,6 +11368,86 @@
       },
       "peerDependencies": {
         "@smartcompanion/data": ">=0.9.0"
+      }
+    },
+    "packages/ui/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "packages/ui/node_modules/@mapbox/vector-tile": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.0.0"
+      }
+    },
+    "packages/ui/node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz",
+      "integrity": "sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "packages/ui/node_modules/maplibre-gl": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.2.0.tgz",
+      "integrity": "sha512-PaNYtxWmYgIdDHshXsnU3Pho+H9IPme9H6dTjZbFWNazi+Q5QgKgIlu2GiSGVtOZ77/Fz3n5/1/kGM6ETzu0Lg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.2.1",
+        "@maplibre/mlt": "^1.1.12",
+        "@maplibre/vt-pbf": "^4.3.2",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.2.3",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^5.1.2",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "packages/ui/node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     }
   }

--- a/packages/ui/custom-elements.json
+++ b/packages/ui/custom-elements.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-08-07T06:45:58",
+  "timestamp": "2026-08-08T09:43:50",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.43.5",

--- a/packages/ui/custom-elements.json
+++ b/packages/ui/custom-elements.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-08-08T09:43:50",
+  "timestamp": "2026-08-07T06:45:58",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.43.5",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -84,7 +84,7 @@
     "build-storybook": "rm -rf dist/components && STORYBOOK=true storybook build"
   },
   "dependencies": {
-    "maplibre-gl": "^5.24.0",
+    "maplibre-gl": "^6.2.0",
     "swiper": "^14.1.0"
   },
   "peerDependencies": {

--- a/packages/ui/src/pages/page-map/page-map.scss
+++ b/packages/ui/src/pages/page-map/page-map.scss
@@ -1,4 +1,4 @@
-@use '../../../../../node_modules/maplibre-gl/dist/maplibre-gl';
+@use '~maplibre-gl/dist/maplibre-gl.css';
 
 .map-holder {
   top: 0px;

--- a/packages/ui/src/pages/page-map/page-map.tsx
+++ b/packages/ui/src/pages/page-map/page-map.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop, Host, h } from '@stencil/core';
-import maplibregl from 'maplibre-gl';
-import type { Map as MapLibreMap, Marker as MapLibreMarker } from 'maplibre-gl';
+// maplibre-gl 6 dropped its default export, so the classes are named imports.
+// They double as the types, which is why there is no separate `import type`.
+import { AttributionControl, Map as MapLibreMap, Marker as MapLibreMarker } from 'maplibre-gl';
 import { StationListFacade } from '../../contracts';
 import { Station } from '@smartcompanion/data';
 import { getMenuButton, getStations, openStation } from '../../utils';
@@ -66,7 +67,7 @@ export class PageMap {
   }
 
   async componentDidLoad() {
-    this.map = new maplibregl.Map({
+    this.map = new MapLibreMap({
       attributionControl: false,
       center: getMapCenter(this.mapBounds),
       container: this.mapContainer,
@@ -81,7 +82,7 @@ export class PageMap {
     });
 
     this.map.touchZoomRotate.disableRotation();
-    this.map.addControl(new maplibregl.AttributionControl({ customAttribution: this.mapAttribution, compact: false }));
+    this.map.addControl(new AttributionControl({ customAttribution: this.mapAttribution, compact: false }));
 
     await this.stationMarkers();
   }
@@ -102,7 +103,7 @@ export class PageMap {
       if (station.latitude !== undefined && station.longitude !== undefined) {
         const markerElement = createStationMarkerElement(station.number ?? '');
 
-        const marker = new maplibregl.Marker({ anchor: 'bottom', element: markerElement });
+        const marker = new MapLibreMarker({ anchor: 'bottom', element: markerElement });
 
         marker.setLngLat([station.longitude, station.latitude]);
         marker.on('click', () => {


### PR DESCRIPTION
> Stacked on #89 — base retargets to `main` automatically once that merges.

## What changed

Updates the bundled map renderer to **maplibre-gl 6.2.0**. `sc-page-map` behaves exactly as before: same props, same markers, same attribution, same disabled rotation. Apps bundling this package pull maplibre 6 instead of 5.

## Two things had to move

**1. maplibre 6 removed its default export.** `import maplibregl from 'maplibre-gl'` no longer compiles — the build fails with *"has no default export"*. The component now imports `Map`, `Marker` and `AttributionControl` by name; the classes double as their own types, so the separate `import type` line is gone. Internal only, no API change.

**2. The stylesheet import was broken by hoisting.** It reached into the repository root's `node_modules` by relative path:

```diff
- @use '../../../../../node_modules/maplibre-gl/dist/maplibre-gl';
+ @use '~maplibre-gl/dist/maplibre-gl.css';
```

npm places maplibre 6 under `packages/ui/node_modules` rather than hoisting it to the root — confirmed after a clean `npm ci`, so the old path was permanently broken, not intermittently. The `~` form is what `page-stations.scss` already uses for swiper, and resolves wherever npm puts the package. Verified the CSS is still inlined into `dist/collection/pages/page-map/page-map.css`.

The only documented breaking change in 6.0.0 is the `Hash` location control, which this component does not use.

## Verification

The browser test added in #85 earns its keep here — it passes unchanged against maplibre 6: canvas created, markers placed, clicks routed.

End to end against the real consumer:

- `audioguide-app` builds clean against a packed tarball, with **maplibre 6.2.0** in its bundle
- its own wdio suite passes **4/4 spec files** in Chrome

Library side: `build`, `lint`, `format:check`, `depcruise`, `check:publish` (3/3), full suite 103 + 15 + 97 passing.

## Packages touched

- [ ] `@smartcompanion/data`
- [ ] `@smartcompanion/services`
- [x] `@smartcompanion/ui`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run depcruise` passes
- [x] `npm test` passes
- [x] A changeset is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
