### PR TITLE
docs: add a Code of Conduct and mark the workspace root private

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<hello@smartcompanion.app>.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/inclusion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 This guide covers working on the three packages in this monorepo: `@smartcompanion/data`, `@smartcompanion/services`, and `@smartcompanion/ui`.
 
+Taking part in this project — issues, discussions, pull requests — means following our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Developing
 
 ### Local setup

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ npm run storybook -w packages/ui   # Dev server at http://localhost:6006
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the local setup, the test layout, and the package boundaries enforced by `npm run depcruise`. Security issues go through [SECURITY.md](SECURITY.md), not the issue tracker.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the local setup, the test layout, and the package boundaries enforced by `npm run depcruise`. Everyone taking part is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md). Security issues go through [SECURITY.md](SECURITY.md), not the issue tracker.
 
 ## Releasing
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "smartcompanion",
+  "private": true,
+  "description": "Monorepo for the SmartCompanion library packages: data, services and UI components for audio-guide apps.",
   "author": "SmartCompanion Team <hello@smartcompanion.app> (https://smartcompanion.app) ",
   "repository": {
     "type": "git",

--- a/packages/ui/custom-elements.json
+++ b/packages/ui/custom-elements.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-08-07T06:45:58",
+  "timestamp": "2026-08-08T10:08:54",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.43.5",


### PR DESCRIPTION
Two visibility/health items.

**Code of Conduct** — Contributor Covenant 2.1, with `hello@smartcompanion.app` as the enforcement contact (the address `SECURITY.md` already points at). Linked from the README's Contributing section and from the top of `CONTRIBUTING.md`. GitHub's community-standards checklist for this repo listed it as the only missing file; adding it also puts a "Code of conduct" entry in the repo sidebar and the new-contributor flow.

**Root `package.json`** — adds `"private": true` and a `description`. The workspace root is named `smartcompanion` and was publishable; `private` makes an accidental `npm publish` from the root impossible. It has no effect on the three published packages or on `changeset publish`, and `npm install --package-lock-only` produces no lockfile change.

No changeset — nothing published changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)