### PR TITLE
chore(ui): stop custom-elements.json churning on every build

### DIFF
--- a/packages/ui/custom-elements.json
+++ b/packages/ui/custom-elements.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-08-08T10:08:54",
+  "timestamp": "1970-01-01T00:00:00",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.43.5",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -73,7 +73,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "stencil build",
+    "build": "stencil build && node scripts/pin-docs-timestamp.mjs",
     "lint": "eslint src",
     "format": "prettier --write src",
     "format:check": "prettier --check src",

--- a/packages/ui/scripts/pin-docs-timestamp.mjs
+++ b/packages/ui/scripts/pin-docs-timestamp.mjs
@@ -1,0 +1,21 @@
+// Stencil's `docs-json` output target stamps custom-elements.json with the time
+// of the build, so the checked-in manifest came out modified after every build
+// even when nothing about the components had changed. Pin that one field once
+// the build has written the file: the manifest then only shows up in `git
+// status` when the components themselves changed.
+//
+// Nothing reads the timestamp — Storybook consumes `components` via
+// setCustomElementsManifest() in .storybook/preview.ts, and the file is not
+// part of the published tarball.
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const PINNED_TIMESTAMP = '1970-01-01T00:00:00';
+
+const manifestPath = fileURLToPath(new URL('../custom-elements.json', import.meta.url));
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+
+manifest.timestamp = PINNED_TIMESTAMP;
+
+// Matches the formatting docs-json writes: two-space indent, no trailing newline.
+await writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');


### PR DESCRIPTION
`packages/ui/custom-elements.json` is checked in, and Stencil's `docs-json` target writes a `timestamp` field on every build — so `npm run build` always left the file modified, whether or not a component had changed. It churned during an unrelated session, which is what surfaced it.

**Fix:** a post-build script pins the timestamp to a constant. Nothing reads it — Storybook consumes `components` via `setCustomElementsManifest()` in `.storybook/preview.ts`, and the file isn't in the package's `files` list, so it never ships.

The single-line change to the committed manifest in this PR is the one-time normalization. After it, two consecutive `npm run build` runs leave the working tree clean — verified locally.

**Why not `docs-custom`?** Tried first, since it would need no extra script. Its `generator` receives the raw `JsonDocs`, which still carries the `dirPath`, `readmePath`, `usagesDir` and `fileName` fields that `docs-json` strips — writing it out put absolute local paths (`/Users/.../packages/ui/src/...`) into the manifest, i.e. churn per contributor instead of per build. Rejected.

`npm run watch` still rewrites the timestamp while it runs, since the script only hooks `build`. That's transient and disappears on the next build.

Gates: `lint`, `format:check`, `depcruise` pass locally; CI covers the rest. No changeset — published output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)