### PR TITLE
chore: prepare the 1.0.0 release

### DIFF
--- a/.changeset/great-pans-attend.md
+++ b/.changeset/great-pans-attend.md
@@ -1,0 +1,39 @@
+---
+'@smartcompanion/data': major
+'@smartcompanion/services': major
+'@smartcompanion/ui': major
+---
+
+First stable release.
+
+The three packages have been usable together for a while; what changes here is
+the promise. From 1.0.0 the public surface is settled and semver applies to it:
+a breaking change needs a major, and the entry points a package exposes are the
+ones it will keep exposing.
+
+What that surface is, per package:
+
+- **`@smartcompanion/data`** — the domain services and their updaters, the
+  `Storage` interface with its browser and in-memory implementations, and the
+  online and offline load services.
+- **`@smartcompanion/services`** — `ServiceFacade` and its accessors, plus
+  `AudioPlayerService`, `MenuService` and `RoutingService`.
+- **`@smartcompanion/ui`** — the custom elements, and the entry points named in
+  the package's `exports` map: the root, `./loader`, and `./dist/collection/*`.
+  Deep imports into anything else were never intended as API and no longer
+  resolve.
+
+Two requirements moved in this release and need attention when upgrading from
+0.10.x:
+
+- **`@smartcompanion/native-audio-player` 1.0 is now required** by
+  `@smartcompanion/services`. The plugin renamed its player event, which this
+  package handles internally, but the peer range no longer accepts 0.5.x.
+- **`sc-page-map` renders with maplibre-gl 6.** The component's own props are
+  unchanged; an app that pinned maplibre 5 itself will need to move.
+
+Nothing else about using these packages changes. Most of the work leading here
+went into things that leave no trace in the API — the entry points are declared
+rather than implied, every component has a rendering test, the packages carry
+READMEs, and one API removal that shipped undocumented in 0.10.0 is now on the
+record.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Driven by [changesets](https://github.com/changesets/changesets), not by tags �
 
 1. Any change to published behaviour ships with a changeset (`npm run changeset`), committed alongside it. All three packages are versioned in lockstep (`fixed` in `.changeset/config.json`), so one changeset bumps all three.
 
-   The peer range on `@smartcompanion/data` in `services` and `ui` is `^1.0.0`. Changesets escalates a peer *dependent* to a major bump whenever the new dependency version falls outside its declared range. On 0.x that made a caret unusable — `^0.9.x` excludes `0.10.0`, so every release came out a major, and the range was a `>=0.9.0` floor to avoid it. A caret is correct now that these packages are on 1.x: minors stay in range, and only a 2.0.0 escalates, which is what should happen when all three go major together.
+   The peer range on `@smartcompanion/data` in `services` and `ui` is `^1.0.0`. Changesets escalates a peer *dependent* to a major bump whenever the new dependency version falls outside its declared range. On 0.x that made a caret unusable — `^0.9.x` excludes `0.10.0`, so every release came out a major, and the range was a `>=0.9.0` floor to avoid it. From 1.0.0 onward a caret is the right form: minors stay in range, and only a 2.0.0 escalates, which is what should happen when all three go major together. Keep the caret.
 
 2. Merging to `main` opens a `chore: release` PR with the version bumps and changelogs.
 3. Merging that PR publishes to npm over trusted publishing (OIDC) with provenance. No npm token exists in this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Driven by [changesets](https://github.com/changesets/changesets), not by tags �
 
 1. Any change to published behaviour ships with a changeset (`npm run changeset`), committed alongside it. All three packages are versioned in lockstep (`fixed` in `.changeset/config.json`), so one changeset bumps all three.
 
-   The peer range on `@smartcompanion/data` in `services` and `ui` is deliberately `>=0.9.0`, not `^0.9.0`. Changesets escalates a peer *dependent* to a major bump whenever the new dependency version falls outside its declared range, and `^0.9.x` excludes `0.10.0` — with a caret there, every release would come out as a major. Do not tighten it while these packages are on 0.x.
+   The peer range on `@smartcompanion/data` in `services` and `ui` is `^1.0.0`. Changesets escalates a peer *dependent* to a major bump whenever the new dependency version falls outside its declared range. On 0.x that made a caret unusable — `^0.9.x` excludes `0.10.0`, so every release came out a major, and the range was a `>=0.9.0` floor to avoid it. A caret is correct now that these packages are on 1.x: minors stay in range, and only a 2.0.0 escalates, which is what should happen when all three go major together.
 
 2. Merging to `main` opens a `chore: release` PR with the version bumps and changelogs.
 3. Merging that PR publishes to npm over trusted publishing (OIDC) with provenance. No npm token exists in this repo.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11331,7 +11331,7 @@
       "peerDependencies": {
         "@capacitor/core": "^8.3.1",
         "@ionic/core": "^8.7.2",
-        "@smartcompanion/data": ">=0.9.0",
+        "@smartcompanion/data": "^1.0.0",
         "@smartcompanion/native-audio-player": "^1.0.0"
       }
     },
@@ -11367,7 +11367,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@smartcompanion/data": ">=0.9.0"
+        "@smartcompanion/data": "^1.0.0"
       }
     },
     "packages/ui/node_modules/@mapbox/unitbezier": {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -56,7 +56,7 @@
   "peerDependencies": {
     "@capacitor/core": "^8.3.1",
     "@ionic/core": "^8.7.2",
-    "@smartcompanion/data": ">=0.9.0",
+    "@smartcompanion/data": "^1.0.0",
     "@smartcompanion/native-audio-player": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -88,7 +88,7 @@
     "swiper": "^14.1.0"
   },
   "peerDependencies": {
-    "@smartcompanion/data": ">=0.9.0"
+    "@smartcompanion/data": "^1.0.0"
   },
   "devDependencies": {
     "@smartcompanion/data": "^0.10.0",


### PR DESCRIPTION
## What changed

Prepares the **1.0.0** release. Two things: a major changeset, and the peer range that only made sense on 0.x.

## The changeset

A `major` on all three packages. The API has been usable together for a while — what changes is the promise. From 1.0.0 the public surface is settled and semver applies to it, so the note says what that surface *is* per package rather than just announcing a number.

It also calls out the two requirements that actually moved, since they need attention when upgrading from 0.10.x:

- **`@smartcompanion/native-audio-player` 1.0 is now required** by `services` — the peer no longer accepts 0.5.x
- **`sc-page-map` renders with maplibre-gl 6** — the component's own props are unchanged

## The peer range

`@smartcompanion/data` in `services` and `ui` goes from the `>=0.9.0` floor to `^1.0.0`.

The floor existed for a real reason, recorded in CLAUDE.md: changesets escalates a peer dependent to a major whenever the dependency lands outside its declared range, and on 0.x a caret fired that every release, because `^0.9.x` excludes `0.10.0`. **That reasoning expires at 1.x.** Leaving the floor would publish 1.0.0 packages claiming to work with `data` 0.9.x — which they don't, since all three are versioned in lockstep.

CLAUDE.md carried the old rule as standing guidance, so it now explains why a caret is right on 1.x instead.

## Verification

Checked rather than assumed, because the escalation behaviour is the thing that bites here:

- `changeset version` in a throwaway worktree puts all three on **1.0.0**, with the peer settling at `^1.0.0` and **no further escalation**
- `npm ci` is happy with the tightened range *even before* the release bump lands, so this branch is installable as it stands
- `build`, `lint`, `format:check`, `depcruise` (148 modules), `check:publish` (3/3), full suite — 103 + 15 + 97 passing
- `npm audit` — 0 vulnerabilities

## After merging

The `chore: release` PR (#82) will rebuild itself against this and cut **1.0.0**. Merging *that* publishes to npm.

## Packages touched

- [x] `@smartcompanion/data`
- [x] `@smartcompanion/services`
- [x] `@smartcompanion/ui`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run depcruise` passes
- [x] `npm test` passes
- [x] A changeset is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
