### PR TITLE
fix(ui): scope page-stations styles to its own host

### DIFF
--- a/.changeset/olive-eagles-shout.md
+++ b/.changeset/olive-eagles-shout.md
@@ -1,0 +1,23 @@
+---
+'@smartcompanion/ui': patch
+---
+
+Stop `sc-page-stations` from restyling the rest of the app. Its stylesheet
+selected `ion-header`, `ion-toolbar` and `ion-card` by bare element name, and
+the page components declare neither `shadow` nor `scoped`, so those rules were
+injected as global CSS and applied everywhere once the page had rendered.
+
+The visible symptom was on `sc-page-selection`: `ion-header { position:
+absolute }` took the header out of flow, so Ionic computed no offset for the
+fullscreen content and the number input sat behind the toolbar wherever the
+status bar contributes a safe-area inset. Browsers and Storybook were fine,
+Android with edge-to-edge was not.
+
+Every rule now lives under `sc-page-stations`, matching what `page-station.scss`
+already does with `#station`. The page looks the same.
+
+One knock-on worth knowing: `ion-card` on `sc-page-multi-audio-station` and
+`sc-page-station-image-list` was picking up `margin-top: 0` and
+`margin-bottom: 10px` from this leak, so those cards go back to Ionic's default
+margins. Their spacing previously depended on whether the stations page had been
+visited first.

--- a/.changeset/olive-eagles-shout.md
+++ b/.changeset/olive-eagles-shout.md
@@ -21,3 +21,9 @@ One knock-on worth knowing: `ion-card` on `sc-page-multi-audio-station` and
 `margin-bottom: 10px` from this leak, so those cards go back to Ionic's default
 margins. Their spacing previously depended on whether the stations page had been
 visited first.
+
+`sc-page-selection` also drops the `margin-top: 50px` on its fixed-slot
+wrapper. That offset existed to push the number input clear of the leaked
+absolute header; with the header back in normal flow the content area already
+starts below it, and the input keeps its own 50px top margin. The input sits
+50px lower than the toolbar rather than 100px.

--- a/packages/ui/src/pages/page-selection/page-selection.scss
+++ b/packages/ui/src/pages/page-selection/page-selection.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   align-items: center;
   width: 100%;
-  margin-top: 50px;
 }
 
 .numpad-input {

--- a/packages/ui/src/pages/page-stations/page-stations.browser.tsx
+++ b/packages/ui/src/pages/page-stations/page-stations.browser.tsx
@@ -185,6 +185,9 @@ describe('sc-page-stations', () => {
     const root = await renderPage();
 
     const own = root.querySelector('ion-header');
-    expect(getComputedStyle(own).position).toBe('absolute');
+    // Without this, a markup change that drops the header surfaces as a
+    // getComputedStyle TypeError rather than as this test failing.
+    expect(own, 'sc-page-stations should render an ion-header').not.toBeNull();
+    expect(getComputedStyle(own!).position).toBe('absolute');
   });
 });

--- a/packages/ui/src/pages/page-stations/page-stations.browser.tsx
+++ b/packages/ui/src/pages/page-stations/page-stations.browser.tsx
@@ -159,4 +159,32 @@ describe('sc-page-stations', () => {
       })
       .toBe(true);
   });
+
+  // Regression test for #95. These page components declare neither `shadow` nor
+  // `scoped`, so this stylesheet is injected as global CSS. While its rules were
+  // written as bare element selectors, rendering this page restyled `ion-header`
+  // for the whole app -- which pushed the number input on sc-page-selection
+  // behind the toolbar wherever the status bar contributes a safe-area inset.
+  //
+  // Asserting on a header outside the page is the point: a header *inside* it is
+  // meant to be absolute, and would pass either way.
+  it('should not restyle ion-header outside the page', async () => {
+    await renderPage();
+
+    const outside = document.createElement('ion-header');
+    document.body.appendChild(outside);
+
+    try {
+      expect(getComputedStyle(outside).position).not.toBe('absolute');
+    } finally {
+      outside.remove();
+    }
+  });
+
+  it('should still position its own header absolutely', async () => {
+    const root = await renderPage();
+
+    const own = root.querySelector('ion-header');
+    expect(getComputedStyle(own).position).toBe('absolute');
+  });
 });

--- a/packages/ui/src/pages/page-stations/page-stations.scss
+++ b/packages/ui/src/pages/page-stations/page-stations.scss
@@ -1,134 +1,141 @@
 @use '~swiper/swiper-bundle.css';
 
-ion-toolbar {
-  --background: transparent;
-}
-ion-header {
-  position: absolute !important;
-}
-ion-card {
-  margin-top: 0px;
-  margin-bottom: 10px;
-}
+// Every rule below is scoped to the host element. These page components declare
+// neither `shadow` nor `scoped`, so their stylesheets are injected as global
+// CSS -- a bare `ion-header` selector here restyled the header on every page of
+// the consuming app, not just this one. See #95. page-station.scss scopes the
+// same rules under `#station` for the same reason.
+sc-page-stations {
+  ion-toolbar {
+    --background: transparent;
+  }
+  ion-header {
+    position: absolute !important;
+  }
+  ion-card {
+    margin-top: 0px;
+    margin-bottom: 10px;
+  }
 
-#player-main {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
+  #player-main {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
 
-#player-image {
-  flex: 280px 0 0;
-  width: 100%;
-  height: 280px;
-
-  img {
-    display: block;
+  #player-image {
+    flex: 280px 0 0;
     width: 100%;
     height: 280px;
-    object-fit: cover;
-  }
-
-  @media (min-width: 768px) {
-    flex: 420px;
-    height: 420px;
 
     img {
-      height: 420px;
-    }
-  }
-}
-
-#player {
-  margin-top: -18px;
-  padding: 0 20px;
-
-  &-controls {
-    display: flex;
-    justify-content: center;
-    margin-top: -30px;
-
-    &-play {
-      margin-left: 10px;
-      margin-right: 10px;
-      width: 70px;
-      height: 70px;
-      margin-top: -5px;
-    }
-  }
-}
-
-#player-list {
-  box-shadow: 0 -4px 7px -7px grey;
-  background: var(--ion-background-color);
-  padding-top: 10px;
-  flex: 50vh 1 1;
-
-  &.swiper {
-    margin-left: 0;
-    margin-right: 0;
-  }
-
-  .swiper-slide {
-    height: auto;
-    opacity: 0.5;
-  }
-
-  .active {
-    opacity: 1;
-  }
-
-  .card-content {
-    display: flex;
-    height: 80px;
-    width: 100%;
-
-    &-text {
-      flex: 100% 1 1;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-template-areas: 'station subtitle' 'title title';
-      padding: 0 10px;
-    }
-
-    img {
-      flex: 80px 0 0;
-      height: 80px;
-      max-width: 80px;
+      display: block;
+      width: 100%;
+      height: 280px;
       object-fit: cover;
     }
 
-    sc-station-icon {
-      grid-area: station;
-      align-self: end;
-    }
+    @media (min-width: 768px) {
+      flex: 420px;
+      height: 420px;
 
-    .subtitle {
-      margin: 0;
-      padding: 0;
-      grid-area: subtitle;
-      align-self: end;
-      justify-self: end;
-      color: var(--sc-station-list-subtitle, var(--ion-color-primary));
-      border: 2px solid var(--sc-station-list-subtitle, var(--ion-color-primary));
-      border-radius: 20px;
-      padding: 2px 7px;
-      font-size: 0.9em;
-      margin-bottom: 4px;
-    }
-
-    .title {
-      margin: 0;
-      padding: 5px 0;
-      grid-area: title;
-      font-weight: bold;
-
-      @media (min-width: 375px) {
-        font-size: 1.3em;
+      img {
+        height: 420px;
       }
-      @media (max-width: 374px) {
-        font-size: 1.1em;
-        line-height: 1.2;
+    }
+  }
+
+  #player {
+    margin-top: -18px;
+    padding: 0 20px;
+
+    &-controls {
+      display: flex;
+      justify-content: center;
+      margin-top: -30px;
+
+      &-play {
+        margin-left: 10px;
+        margin-right: 10px;
+        width: 70px;
+        height: 70px;
+        margin-top: -5px;
+      }
+    }
+  }
+
+  #player-list {
+    box-shadow: 0 -4px 7px -7px grey;
+    background: var(--ion-background-color);
+    padding-top: 10px;
+    flex: 50vh 1 1;
+
+    &.swiper {
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    .swiper-slide {
+      height: auto;
+      opacity: 0.5;
+    }
+
+    .active {
+      opacity: 1;
+    }
+
+    .card-content {
+      display: flex;
+      height: 80px;
+      width: 100%;
+
+      &-text {
+        flex: 100% 1 1;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-areas: 'station subtitle' 'title title';
+        padding: 0 10px;
+      }
+
+      img {
+        flex: 80px 0 0;
+        height: 80px;
+        max-width: 80px;
+        object-fit: cover;
+      }
+
+      sc-station-icon {
+        grid-area: station;
+        align-self: end;
+      }
+
+      .subtitle {
+        margin: 0;
+        padding: 0;
+        grid-area: subtitle;
+        align-self: end;
+        justify-self: end;
+        color: var(--sc-station-list-subtitle, var(--ion-color-primary));
+        border: 2px solid var(--sc-station-list-subtitle, var(--ion-color-primary));
+        border-radius: 20px;
+        padding: 2px 7px;
+        font-size: 0.9em;
+        margin-bottom: 4px;
+      }
+
+      .title {
+        margin: 0;
+        padding: 5px 0;
+        grid-area: title;
+        font-weight: bold;
+
+        @media (min-width: 375px) {
+          font-size: 1.3em;
+        }
+        @media (max-width: 374px) {
+          font-size: 1.1em;
+          line-height: 1.2;
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #95.

## The leak

`page-stations.scss` selected `ion-header`, `ion-toolbar` and `ion-card` by bare element name. The page components declare neither `shadow` nor `scoped`, so Stencil injects their stylesheets as **global CSS** — rendering this page once restyled those elements across the whole app.

`ion-header { position: absolute !important }` was the damaging one, exactly as the issue describes: on `sc-page-selection` it took the header out of flow, Ionic computed `--offset-top: 0` for the fullscreen content, and the number input landed behind the toolbar wherever the status bar contributes a safe-area inset. Hence Android edge-to-edge broken, browser fine.

## The fix

Every rule now sits under `sc-page-stations`. This is not a new pattern — `page-station.scss` already scopes the *identical* `ion-header { position: absolute !important }` under `#station`, and `page-tabbed-station-list.scss` wraps itself in its own tag. `page-stations.scss` was the outlier. The page renders identically.

## Tests

Two browser tests, because this bug is invisible from inside the page:

- an `ion-header` appended **outside** the component is not absolutely positioned
- the page's **own** header still is

Asserting on a header outside the page is the whole point — one inside is *meant* to be absolute and would pass either way.

**Verified the first test catches this rather than passing vacuously:** against the unscoped stylesheet it fails; against the scoped one it passes.

## Audit of the other stylesheets

You asked whether anything else leaks. Eleven page components render in light DOM. Checking every one of their stylesheets for top-level element selectors:

| Stylesheet | Finding |
| --- | --- |
| `page-stations.scss` | **`ion-toolbar`, `ion-header`, `ion-card`** — this bug |
| `page-station.scss` | already scoped under `#station` ✅ |
| `page-tabbed-station-list.scss` | already scoped under its own tag ✅ |
| `page-loading.scss` | reaches global ids (`#loading`, `#loading-image`) |
| `page-tour-list.scss` | `:root.ion-palette-dark .tour-card` — global class |
| the other six | no top-level element selectors |

**No other stylesheet overrides an `ion-` element globally.** The id/class exposure in `page-loading` and `page-tour-list` is the same category but a different severity — it collides only with a consumer using those exact names, rather than restyling a core Ionic element app-wide. Left alone here; worth a follow-up if you want the light-DOM pages tightened generally.

## One knock-on worth knowing

`ion-card` on `sc-page-multi-audio-station` and `sc-page-station-image-list` was picking up `margin-top: 0` / `margin-bottom: 10px` from this leak. Those cards go back to Ionic's default margins. Their spacing previously depended on whether the stations page had been visited first — the styles are lazily injected — so this makes them deterministic rather than changing a deliberate design. Called out in the changeset.

## Verification

`build`, `lint`, `format:check`, `depcruise` (148 modules), `check:publish` (3/3), full suite — 103 + 15 + 99 passing.

> Unrelated but worth flagging: the browser project silently ran zero tests here until I ran `npx playwright install chromium`. The dependency refresh bumped Playwright and its browser build no longer matched. CI installs browsers explicitly so it was unaffected, but locally it looked like a green run with 17 fewer tests.

## Packages touched

- [ ] `@smartcompanion/data`
- [ ] `@smartcompanion/services`
- [x] `@smartcompanion/ui`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run depcruise` passes
- [x] `npm test` passes
- [x] A changeset is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
