### PR TITLE
fix(ui): keep the stations list clear of the navigation bar

### DIFF
--- a/.changeset/olive-pandas-smile.md
+++ b/.changeset/olive-pandas-smile.md
@@ -1,0 +1,20 @@
+---
+'@smartcompanion/ui': patch
+---
+
+Keep the `sc-page-stations` list clear of the Android navigation bar. The page
+renders `<ion-content fullscreen>`, so it spans the whole screen, and Ionic
+applies the bottom safe-area inset only to content inside a modal. The station
+list therefore ran to the bottom of the screen and its last card sat under the
+navigation bar — permanently, since the list is a vertical swiper whose viewport
+ended there too, so scrolling could not bring the card into view.
+
+`#player-list` now carries `margin-bottom: var(--ion-safe-area-bottom, 0px)`.
+This has to be a margin rather than padding: swiper sizes its viewport from the
+container's `clientHeight`, which includes padding, so `padding-bottom` would
+leave the container reaching the bottom of the screen and the slides would
+simply extend into the padded region.
+
+Consumers carrying the `sc-page-stations #player-list { margin-bottom: ... }`
+workaround can drop it. Where the inset is zero — browsers, Storybook, devices
+without a visible navigation bar — the rule is inert and the page is unchanged.

--- a/packages/ui/src/pages/page-stations/page-stations.browser.tsx
+++ b/packages/ui/src/pages/page-stations/page-stations.browser.tsx
@@ -181,6 +181,40 @@ describe('sc-page-stations', () => {
     }
   });
 
+  // Regression test for #96. `ion-content` is `fullscreen`, so it spans the whole
+  // screen and Ionic applies no bottom safe-area inset outside a modal -- the
+  // list ran under the Android navigation bar and its last card was permanently
+  // obscured, scrolled to the end or not.
+  //
+  // The margin has to stay a *margin*: swiper sizes its viewport from the
+  // container's `clientHeight`, which includes padding, so `padding-bottom` lets
+  // the slides extend into the padded region and the container still reaches the
+  // bottom of the screen. Asserting on `marginBottom` is what pins that down.
+  describe('bottom safe-area inset', () => {
+    const listMarginBottom = async (inset?: string) => {
+      const root = await renderPage();
+
+      if (inset !== undefined) {
+        document.documentElement.style.setProperty('--ion-safe-area-bottom', inset);
+      }
+
+      try {
+        return getComputedStyle(list(root)).marginBottom;
+      } finally {
+        document.documentElement.style.removeProperty('--ion-safe-area-bottom');
+      }
+    };
+
+    it('should keep the list clear of the navigation bar', async () => {
+      expect(await listMarginBottom('48px')).toBe('48px');
+    });
+
+    // Browsers and Storybook report no inset, where the rule has to be inert.
+    it('should not reserve space where there is no inset', async () => {
+      expect(await listMarginBottom()).toBe('0px');
+    });
+  });
+
   it('should still position its own header absolutely', async () => {
     const root = await renderPage();
 

--- a/packages/ui/src/pages/page-stations/page-stations.scss
+++ b/packages/ui/src/pages/page-stations/page-stations.scss
@@ -69,6 +69,13 @@ sc-page-stations {
     background: var(--ion-background-color);
     padding-top: 10px;
     flex: 50vh 1 1;
+    // The content is `fullscreen`, so it spans the whole screen and nothing
+    // applies the bottom safe-area inset -- the list ran under the Android
+    // navigation bar, hiding its last card. See #96. This has to be a margin:
+    // swiper sizes its viewport from the container's `clientHeight`, which
+    // includes padding, so `padding-bottom` leaves the container reaching the
+    // bottom of the screen and the slides simply extend into the padded region.
+    margin-bottom: var(--ion-safe-area-bottom, 0px);
 
     &.swiper {
       margin-left: 0;


### PR DESCRIPTION
Closes #96. Re-lands #99, which was merged into a dead-end branch and never reached `main`.

### What went wrong with #99

#99 was stacked on `fix/page-stations-global-styles` (#97) to avoid a conflict — that PR re-indents
every line of `page-stations.scss`. #97 was squash-merged into `main` at 16:52, but its branch was
not deleted, so GitHub never retargeted #99. #99 was then merged at 17:05 into that now-orphaned
branch and went nowhere:

```
$ git branch -r --contains 998fb7d
  origin/fix/page-stations-bottom-safe-area     ← only here; not on main
```

Hence #96 did not auto-close (`Closes` only fires on the default branch) and release PR #98 was not
updated (`release.yml` runs on pushes to `main`, and the changeset never arrived).

This branch is that same commit cherry-picked onto `main`. It applies cleanly —
`git diff --stat 1ff8d72 origin/main` is empty, so #97's squash reproduced the branch tree exactly.
The content is unchanged from #99, which passed CI.

### The fix

`sc-page-stations` renders `<ion-content fullscreen>`, so the page spans the whole screen, and the
station list ran to the bottom of it — its last card sat under the Android navigation bar,
permanently, since the list is a vertical swiper whose viewport ended there too and scrolling could
not bring the card into view.

```diff
 #player-list {
   box-shadow: 0 -4px 7px -7px grey;
   background: var(--ion-background-color);
   padding-top: 10px;
   flex: 50vh 1 1;
+  margin-bottom: var(--ion-safe-area-bottom, 0px);
```

### Why nothing was already handling this

Ionic's `content.css` composes the inner scroll's padding from
`--padding-bottom + --keyboard-offset + --offset-bottom + --internal-content-safe-area-padding-bottom`,
and the only writer of that last variable is `modal.js`. Outside a modal Ionic applies no bottom
inset at all — `fullscreen` or not, footer or not. That confirms the issue's note that this is not
fixed by fixing #95: `--offset-bottom` compensates for a footer element, and this page has none.

### Why a margin and not padding

Swiper sizes its viewport from the container's `clientHeight`, which includes padding, so
`padding-bottom` leaves the container reaching the bottom of the screen and the slides simply extend
into the padded region. Measured on device: `padding-bottom` → `#player-list` bottom = 923 ❌,
`margin-bottom` → 875 ✅.

### Test

`page-stations.browser.tsx` sets `--ion-safe-area-bottom: 48px` on the document and asserts the
list's computed `marginBottom`, plus an inert-at-zero case. Asserting on `marginBottom` specifically
is what pins down the padding-vs-margin trap — verified by mutation: swapping the rule to
`padding-bottom` makes the test report `0px` against the expected `48px`. A geometry assertion is not
available here, since the browser tests load only the Stencil bundle and `ion-content` has no real
Ionic layout.

### Not included: the other list pages

The issue's "worth auditing" list is left alone — it needs device measurement. What the code shows:

- `page-station-list`, `page-tour-list` and `page-multi-audio-station` have the same gap in
  principle, since Ionic applies no bottom inset to them either. They scroll natively, so the symptom
  is milder — the last item is reachable, just clipped at rest.
- `page-tabbed-station-list` is why this was not blanket-applied. It embeds `sc-page-station-list`
  inside `ion-tab` with an `<ion-tab-bar slot="bottom">` and already carries
  `ion-list { margin-bottom: 56px }`. An inset on `page-station-list` would apply inside the tabbed
  page too and risks double-counting against whatever the tab bar handles itself.

Worth its own issue.

### Consumers

The `sc-page-stations #player-list { margin-bottom: ... }` workaround in `schloss-landeck` and
`schloss-tratzberg` can be dropped once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
