### PR TITLE
fix(ui): apply the bottom safe-area inset on every page, not just one

### DIFF
--- a/.changeset/quiet-pianos-shave.md
+++ b/.changeset/quiet-pianos-shave.md
@@ -1,0 +1,38 @@
+---
+'@smartcompanion/ui': patch
+---
+
+Keep every page's content clear of the Android navigation bar, not just
+`sc-page-stations`. Under an edge-to-edge WebView Ionic applies the bottom
+safe-area inset only in the components that own the bottom edge — in
+`@ionic/core` 8.8 exactly `ion-footer`, `ion-tab-bar`, `ion-toast` and
+`ion-picker-legacy`. `ion-content` has the hook but only `ion-modal` ever fills
+it, so any routed page whose content reaches the bottom edge had its lowest
+element obscured, `fullscreen` or not.
+
+`sc-page-station-list`, `sc-page-station-image-list`, `sc-page-tour-list`,
+`sc-page-station`, `sc-page-multi-audio-station`, `sc-page-pin`, `sc-page-error`
+and `sc-page-language` now set `--padding-bottom` on their `ion-content` through
+a shared mixin (`src/styles/_safe-area.scss`), which documents the mechanism and
+the ways it can be got wrong. `sc-page-language` keeps its own 12px as the base
+the inset is added to.
+
+`sc-page-stations` moves from the one-off `#player-list { margin-bottom: … }` of
+the previous release to that same general form; both measured identically on
+device (list bottom at 875 on a 923px screen). Where the inset is zero —
+browsers, Storybook, devices without a visible navigation bar — every one of
+these rules is inert and the pages are unchanged.
+
+Consumers can drop the `sc-page-stations #player-list { margin-bottom: … }`
+workaround and any app-level `--padding-bottom: var(--ion-safe-area-bottom)`
+block over these page tags.
+
+`sc-page-tabbed-station-list` is deliberately unchanged: its inner pages pick the
+inset up from the above, and that composes with the existing flat
+`ion-list { margin-bottom: 56px }` rather than doubling up, since `ion-tab-bar`'s
+real height under edge-to-edge is `56px + inset`. Worth confirming on device.
+
+Still uncovered: `sc-page-selection` and `sc-page-map` put their content in
+`slot="fixed"`, which `--padding-bottom` does not reach. The selection numpad is
+centred and clears the bar, but MapLibre's attribution control does sit in the
+navigation-bar strip and needs its own rule.

--- a/packages/ui/src/pages/bottom-safe-area.browser.tsx
+++ b/packages/ui/src/pages/bottom-safe-area.browser.tsx
@@ -1,0 +1,158 @@
+import { render, h, describe, it, expect } from '@stencil/vitest';
+import {
+  Menu,
+  PageErrorFacade,
+  PageLanguageFacade,
+  PagePinFacade,
+  PageStationFacade,
+  PageTourListFacade,
+  PinValidator,
+  Router,
+  StationListFacade,
+  StationSource,
+  TourSource,
+} from '../contracts';
+import { AudioPlayerService } from '@smartcompanion/services';
+import { Station } from '@smartcompanion/data';
+import { stations as fixtureStations, tours } from '../../test/fixtures';
+
+// Regression test for #101, generalizing the one #96 added for sc-page-stations
+// (which keeps its own, next to the swiper assertions it also needs).
+//
+// Under an edge-to-edge WebView Ionic applies the bottom safe-area inset only in
+// the components that own the bottom edge; `ion-content` gets nothing outside a
+// modal, so a routed page's content ran under the Android navigation bar and its
+// lowest element was obscured. Each page now sets `--padding-bottom` on its
+// `ion-content` -- see src/styles/_safe-area.scss.
+//
+// The assertion is on the computed custom property rather than on the padding of
+// `.inner-scroll`: this project does not load @ionic/core into the browser
+// project (see vitest.setup.ts), so `ion-content` is an undefined element with no
+// shadow root. `getComputedStyle` still substitutes `var()` for custom
+// properties, which is what makes the two halves below meaningful.
+
+const SILENT_AUDIO = 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=';
+
+const stations: Station[] = fixtureStations.map(station => ({
+  ...station,
+  audios: station.audios.map(audio => ({ ...audio, internalFileUrl: SILENT_AUDIO, internalWebUrl: SILENT_AUDIO })),
+}));
+
+const menu = () => ({ enable: () => Promise.resolve(), disable: () => Promise.resolve() }) as Partial<Menu>;
+const stationSource = () => ({ getStations: () => Promise.resolve(stations) }) as Partial<StationSource>;
+const translate = (key: string) => key;
+
+const stationListFacade = {
+  getMenuService: menu,
+  getStationService: stationSource,
+  getTourService: () => ({ getStations: () => Promise.resolve(stations) }) as Partial<TourSource>,
+  __: translate,
+} as unknown as StationListFacade;
+
+const tourListFacade = {
+  getMenuService: menu,
+  getTourService: () => ({ getTours: () => Promise.resolve(tours) }) as Partial<TourSource>,
+  __: translate,
+} as unknown as PageTourListFacade;
+
+// One instance, not one per call: ReactiveAudioPlayer.initAudioPlayer() calls
+// start() and then select() through separate getAudioPlayerService() calls, and
+// a fresh instance for the second has no items -- select() then rejects with
+// "Item with id  doesn't exist" outside the page's own promise chain.
+const audioPlayerService = new AudioPlayerService('');
+
+const stationFacade = {
+  getAudioPlayerService: () => audioPlayerService,
+  getMenuService: menu,
+  getStationService: stationSource,
+  getTourService: () => ({ getStations: () => Promise.resolve(stations) }) as Partial<TourSource>,
+  __: translate,
+} as unknown as PageStationFacade;
+
+const pinFacade = {
+  getPinService: () => ({ validatePin: () => false }) as Partial<PinValidator>,
+  getMenuService: menu,
+  getRoutingService: () => ({ pushReplaceCurrent: () => Promise.resolve() }) as Partial<Router>,
+  __: translate,
+} as unknown as PagePinFacade;
+
+const errorFacade = {
+  getMenuService: menu,
+  getRoutingService: () => ({ pushReplaceCurrent: () => Promise.resolve() }) as Partial<Router>,
+  __: translate,
+} as unknown as PageErrorFacade;
+
+const languageFacade = {
+  getMenuService: menu,
+  getLanguages: () => [{ title: 'English', language: 'en' }],
+} as unknown as PageLanguageFacade;
+
+// `base` is the bottom padding the page already wanted, which the inset is added
+// to rather than replacing. Only sc-page-language has one today; where there is
+// none the computed value is the inset itself, so the assertions read as lengths.
+type PageUnderTest = {
+  name: string;
+  base?: string;
+  renderPage: () => Promise<HTMLElement>;
+  content: (root: HTMLElement) => HTMLElement | null;
+};
+
+const renderer = (node: () => unknown) => async () => {
+  const { root, waitForChanges } = await render(node() as never);
+  await waitForChanges();
+  return root;
+};
+
+const light = (root: HTMLElement) => root.querySelector('ion-content') as HTMLElement | null;
+// sc-page-error and sc-page-language are `shadow: true`, so their stylesheet is
+// scoped for them and its selector needs no host tag -- and their ion-content is
+// reachable only through the shadow root.
+const shadow = (root: HTMLElement) => root.shadowRoot.querySelector('ion-content') as HTMLElement | null;
+
+const pages: PageUnderTest[] = [
+  { name: 'sc-page-station-list', renderPage: renderer(() => <sc-page-station-list facade={stationListFacade}></sc-page-station-list>), content: light },
+  { name: 'sc-page-station-image-list', renderPage: renderer(() => <sc-page-station-image-list facade={stationListFacade}></sc-page-station-image-list>), content: light },
+  { name: 'sc-page-tour-list', renderPage: renderer(() => <sc-page-tour-list facade={tourListFacade}></sc-page-tour-list>), content: light },
+  { name: 'sc-page-station', renderPage: renderer(() => <sc-page-station stationId="1" facade={stationFacade}></sc-page-station>), content: light },
+  { name: 'sc-page-pin', renderPage: renderer(() => <sc-page-pin facade={pinFacade}></sc-page-pin>), content: light },
+  { name: 'sc-page-error', renderPage: renderer(() => <sc-page-error facade={errorFacade}></sc-page-error>), content: shadow },
+  { name: 'sc-page-language', base: '12px', renderPage: renderer(() => <sc-page-language facade={languageFacade}></sc-page-language>), content: shadow },
+];
+
+// An unregistered custom property computes to its substituted token stream, not
+// to an evaluated length, so a page with a base reads back as the calc() itself.
+const expected = (base: string | undefined, inset: string) => (base === undefined ? inset : `calc(${base} + ${inset})`);
+
+const paddingBottom = async (page: PageUnderTest, inset?: string) => {
+  const root = await page.renderPage();
+
+  if (inset !== undefined) {
+    document.documentElement.style.setProperty('--ion-safe-area-bottom', inset);
+  }
+
+  try {
+    const content = page.content(root);
+    // Without this, a markup change that drops the content surfaces as a
+    // getComputedStyle TypeError rather than as the test below failing.
+    expect(content, `${page.name} should render an ion-content`).not.toBeNull();
+    return getComputedStyle(content!).getPropertyValue('--padding-bottom').trim();
+  } finally {
+    document.documentElement.style.removeProperty('--ion-safe-area-bottom');
+    root.remove();
+  }
+};
+
+describe('bottom safe-area inset', () => {
+  for (const page of pages) {
+    describe(page.name, () => {
+      it('should keep the content clear of the navigation bar', async () => {
+        expect(await paddingBottom(page, '48px')).toBe(expected(page.base, '48px'));
+      });
+
+      // Browsers and Storybook report no inset, where the rule has to be inert.
+      it('should not reserve space where there is no inset', async () => {
+        expect(await paddingBottom(page)).toBe(expected(page.base, '0px'));
+      });
+    });
+  }
+});

--- a/packages/ui/src/pages/page-error/page-error.scss
+++ b/packages/ui/src/pages/page-error/page-error.scss
@@ -1,3 +1,5 @@
+@use '../../styles/safe-area';
+
 #error-page {
   display: flex;
   flex-flow: column;
@@ -11,4 +13,9 @@
   width: 150px;
   height: 150px;
   margin-bottom: 45px;
+}
+
+// Keeps the content clear of the Android navigation bar. See #101.
+ion-content {
+  @include safe-area.content-bottom-inset;
 }

--- a/packages/ui/src/pages/page-language/page-language.css
+++ b/packages/ui/src/pages/page-language/page-language.css
@@ -1,6 +1,0 @@
-ion-content {
-  --padding-top: 12px;
-  --padding-bottom: 12px;
-  --padding-start: 12px;
-  --padding-end: 12px;
-}

--- a/packages/ui/src/pages/page-language/page-language.scss
+++ b/packages/ui/src/pages/page-language/page-language.scss
@@ -1,0 +1,10 @@
+@use '../../styles/safe-area';
+
+ion-content {
+  --padding-top: 12px;
+  --padding-start: 12px;
+  --padding-end: 12px;
+  // Keeps the content clear of the Android navigation bar. See #101. The page's
+  // own 12px is the base the inset is added to, not replaced by.
+  @include safe-area.content-bottom-inset(12px);
+}

--- a/packages/ui/src/pages/page-language/page-language.tsx
+++ b/packages/ui/src/pages/page-language/page-language.tsx
@@ -3,7 +3,7 @@ import { PageLanguageFacade } from '../../contracts';
 
 @Component({
   tag: 'sc-page-language',
-  styleUrl: 'page-language.css',
+  styleUrl: 'page-language.scss',
   shadow: true,
 })
 export class PageLanguage {

--- a/packages/ui/src/pages/page-multi-audio-station/page-multi-audio-station.browser.tsx
+++ b/packages/ui/src/pages/page-multi-audio-station/page-multi-audio-station.browser.tsx
@@ -106,4 +106,40 @@ describe('sc-page-multi-audio-station', () => {
       })
       .toBe(true);
   });
+
+  // Regression test for #101 -- the sibling cases for the other pages live in
+  // ../bottom-safe-area.browser.tsx. This page gets its own because it is the one
+  // that trips the specificity trap: its content carries `.ion-no-padding`, which
+  // sets `--padding-bottom: 0` at (0,1,0), so a bare `#multi-audio-station
+  // ion-content` selector would lose to it silently and the inset would never
+  // reach the page. The selector has to name the class -- see
+  // src/styles/_safe-area.scss.
+  //
+  // @ionic/core is not loaded into the browser project, so `ion-content` is an
+  // undefined element with no `.inner-scroll` to measure. `getComputedStyle`
+  // still substitutes `var()` for custom properties, which is the assertion.
+  describe('bottom safe-area inset', () => {
+    const contentPaddingBottom = async (inset?: string) => {
+      const root = await renderPage();
+
+      if (inset !== undefined) {
+        document.documentElement.style.setProperty('--ion-safe-area-bottom', inset);
+      }
+
+      try {
+        return getComputedStyle(root.querySelector('ion-content.ion-no-padding')!).getPropertyValue('--padding-bottom').trim();
+      } finally {
+        document.documentElement.style.removeProperty('--ion-safe-area-bottom');
+      }
+    };
+
+    it('should keep the content clear of the navigation bar', async () => {
+      expect(await contentPaddingBottom('48px')).toBe('48px');
+    });
+
+    // Browsers and Storybook report no inset, where the rule has to be inert.
+    it('should not reserve space where there is no inset', async () => {
+      expect(await contentPaddingBottom()).toBe('0px');
+    });
+  });
 });

--- a/packages/ui/src/pages/page-multi-audio-station/page-multi-audio-station.scss
+++ b/packages/ui/src/pages/page-multi-audio-station/page-multi-audio-station.scss
@@ -1,3 +1,5 @@
+@use '../../styles/safe-area';
+
 #multi-audio-station {
   display: flex;
   flex-flow: column;
@@ -5,6 +7,14 @@
 
   ion-content {
     --background: var(--ion-background-color-step-50);
+  }
+
+  // Keeps the content clear of the Android navigation bar. See #101.
+  // The class has to be in the selector: `.ion-no-padding` sets
+  // `--padding-bottom: 0` at (0,1,0) and a bare `ion-content` would lose. It
+  // also keeps this off the `ion-content.ion-padding` inside the popover.
+  ion-content.ion-no-padding {
+    @include safe-area.content-bottom-inset;
   }
 
   .station-subtitle {

--- a/packages/ui/src/pages/page-pin/page-pin.scss
+++ b/packages/ui/src/pages/page-pin/page-pin.scss
@@ -1,3 +1,5 @@
+@use '../../styles/safe-area';
+
 #pin {
   display: flex;
   flex-direction: column;
@@ -98,4 +100,9 @@
 
 .shake {
   animation: shake 0.5s 1;
+}
+
+// Keeps the content clear of the Android navigation bar. See #101.
+sc-page-pin ion-content {
+  @include safe-area.content-bottom-inset;
 }

--- a/packages/ui/src/pages/page-station-image-list/page-station-image-list.scss
+++ b/packages/ui/src/pages/page-station-image-list/page-station-image-list.scss
@@ -1,3 +1,5 @@
+@use '../../styles/safe-area';
+
 .station-image-list {
   ion-list {
     --ion-item-background: var(--ion-background-color-step-50);
@@ -19,4 +21,9 @@
   &-description {
     padding-bottom: 10px;
   }
+}
+
+// Keeps the content clear of the Android navigation bar. See #101.
+sc-page-station-image-list ion-content {
+  @include safe-area.content-bottom-inset;
 }

--- a/packages/ui/src/pages/page-station-list/page-station-list.scss
+++ b/packages/ui/src/pages/page-station-list/page-station-list.scss
@@ -1,3 +1,5 @@
+@use '../../styles/safe-area';
+
 .station-list {
   h2 {
     font-size: 15px !important;
@@ -7,4 +9,9 @@
     font-size: 13px !important;
     font-weight: normal;
   }
+}
+
+// Keeps the content clear of the Android navigation bar. See #101.
+sc-page-station-list ion-content {
+  @include safe-area.content-bottom-inset;
 }

--- a/packages/ui/src/pages/page-station/page-station.scss
+++ b/packages/ui/src/pages/page-station/page-station.scss
@@ -1,4 +1,11 @@
+@use '../../styles/safe-area';
+
 #station {
+  // Keeps the content clear of the Android navigation bar. See #101.
+  ion-content {
+    @include safe-area.content-bottom-inset;
+  }
+
   ion-toolbar {
     --background: linear-gradient(to bottom, rgba(37, 37, 37, 0.2), rgba(37, 37, 37, 0));
   }

--- a/packages/ui/src/pages/page-stations/page-stations.browser.tsx
+++ b/packages/ui/src/pages/page-stations/page-stations.browser.tsx
@@ -181,17 +181,26 @@ describe('sc-page-stations', () => {
     }
   });
 
-  // Regression test for #96. `ion-content` is `fullscreen`, so it spans the whole
-  // screen and Ionic applies no bottom safe-area inset outside a modal -- the
-  // list ran under the Android navigation bar and its last card was permanently
-  // obscured, scrolled to the end or not.
+  // Regression test for #96, generalized in #101 -- the sibling cases for the
+  // other pages live in ../bottom-safe-area.browser.tsx.
   //
-  // The margin has to stay a *margin*: swiper sizes its viewport from the
-  // container's `clientHeight`, which includes padding, so `padding-bottom` lets
-  // the slides extend into the padded region and the container still reaches the
-  // bottom of the screen. Asserting on `marginBottom` is what pins that down.
+  // `ion-content` is `fullscreen` here, so the page spans the whole screen and
+  // Ionic applies no bottom safe-area inset outside a modal: the list ran under
+  // the Android navigation bar and its last card was permanently obscured,
+  // scrolled to the end or not.
+  //
+  // #96 shortened `#player-list` with a margin, because swiper sizes its viewport
+  // from the container's `clientHeight` and a `padding-bottom` there would have
+  // let the slides extend into the padded region. `--padding-bottom` on the
+  // content is a different lever -- it shortens `.inner-scroll`'s content box, so
+  // `#player-main`, sized from it at `height: 100%`, ends above the navigation bar
+  // and takes the list with it. Both measured identically on device (list bottom
+  // at 875 on a 923px screen), so the page now uses the general form.
+  //
+  // The margin assertion is what keeps the two from being applied at once: with
+  // the general rule in place, restoring #96's margin would inset twice.
   describe('bottom safe-area inset', () => {
-    const listMarginBottom = async (inset?: string) => {
+    const withInset = async <T,>(inset: string | undefined, read: (root: HTMLElement) => T): Promise<T> => {
       const root = await renderPage();
 
       if (inset !== undefined) {
@@ -199,19 +208,30 @@ describe('sc-page-stations', () => {
       }
 
       try {
-        return getComputedStyle(list(root)).marginBottom;
+        return read(root);
       } finally {
         document.documentElement.style.removeProperty('--ion-safe-area-bottom');
       }
     };
 
+    // @ionic/core is not loaded into the browser project, so `ion-content` is an
+    // undefined element with no `.inner-scroll` to measure. `getComputedStyle`
+    // still substitutes `var()` for custom properties, which is the assertion.
+    const contentPaddingBottom = (inset?: string) => withInset(inset, root => getComputedStyle(root.querySelector('ion-content')!).getPropertyValue('--padding-bottom').trim());
+
+    const listMarginBottom = (inset?: string) => withInset(inset, root => getComputedStyle(list(root)).marginBottom);
+
     it('should keep the list clear of the navigation bar', async () => {
-      expect(await listMarginBottom('48px')).toBe('48px');
+      expect(await contentPaddingBottom('48px')).toBe('48px');
     });
 
     // Browsers and Storybook report no inset, where the rule has to be inert.
     it('should not reserve space where there is no inset', async () => {
-      expect(await listMarginBottom()).toBe('0px');
+      expect(await contentPaddingBottom()).toBe('0px');
+    });
+
+    it('should not also shorten the list itself', async () => {
+      expect(await listMarginBottom('48px')).toBe('0px');
     });
   });
 

--- a/packages/ui/src/pages/page-stations/page-stations.scss
+++ b/packages/ui/src/pages/page-stations/page-stations.scss
@@ -1,4 +1,5 @@
 @use '~swiper/swiper-bundle.css';
+@use '../../styles/safe-area';
 
 // Every rule below is scoped to the host element. These page components declare
 // neither `shadow` nor `scoped`, so their stylesheets are injected as global
@@ -6,6 +7,16 @@
 // the consuming app, not just this one. See #95. page-station.scss scopes the
 // same rules under `#station` for the same reason.
 sc-page-stations {
+  // Keeps the content clear of the Android navigation bar. See #101.
+  // This replaces the `#player-list { margin-bottom: ... }` of #96: on device
+  // both measured identically (list bottom at 875 on a 923px screen), because
+  // `--padding-bottom` shortens `.inner-scroll`'s content box and `#player-main`
+  // is sized from it. The swiper caveat in #96 was about `padding-bottom` on
+  // `#player-list` itself, which swiper counts into its own viewport height.
+  ion-content {
+    @include safe-area.content-bottom-inset;
+  }
+
   ion-toolbar {
     --background: transparent;
   }
@@ -69,13 +80,6 @@ sc-page-stations {
     background: var(--ion-background-color);
     padding-top: 10px;
     flex: 50vh 1 1;
-    // The content is `fullscreen`, so it spans the whole screen and nothing
-    // applies the bottom safe-area inset -- the list ran under the Android
-    // navigation bar, hiding its last card. See #96. This has to be a margin:
-    // swiper sizes its viewport from the container's `clientHeight`, which
-    // includes padding, so `padding-bottom` leaves the container reaching the
-    // bottom of the screen and the slides simply extend into the padded region.
-    margin-bottom: var(--ion-safe-area-bottom, 0px);
 
     &.swiper {
       margin-left: 0;

--- a/packages/ui/src/pages/page-tour-list/page-tour-list.scss
+++ b/packages/ui/src/pages/page-tour-list/page-tour-list.scss
@@ -1,3 +1,5 @@
+@use '../../styles/safe-area';
+
 .tour-card {
   position: relative;
   width: 100%;
@@ -65,4 +67,9 @@
   .tour-card .tour-card-transparency {
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.9));
   }
+}
+
+// Keeps the content clear of the Android navigation bar. See #101.
+sc-page-tour-list ion-content {
+  @include safe-area.content-bottom-inset;
 }

--- a/packages/ui/src/styles/_safe-area.scss
+++ b/packages/ui/src/styles/_safe-area.scss
@@ -1,0 +1,46 @@
+// Bottom safe-area inset for routed pages.
+//
+// Under an edge-to-edge WebView (Capacitor 8) Ionic applies the bottom
+// safe-area inset only in the components that own the bottom edge -- in
+// @ionic/core 8.8 exactly `ion-footer`, `ion-tab-bar`, `ion-toast` and
+// `ion-picker-legacy`. `ion-content` has the hook but nothing fills it: its
+// `.inner-scroll` adds `--internal-content-safe-area-padding-bottom`, and only
+// `ion-modal.applyFullscreenSafeAreaTo()` ever sets that. A routed page's
+// content therefore runs under the Android navigation bar, `fullscreen` or not,
+// and its lowest element is obscured. See #101, and #96 for the first sighting.
+//
+// Include this on the `ion-content` of every page whose content scrolls to the
+// bottom edge, passing whatever bottom padding the page already wanted as
+// `$base`. Where the inset is zero -- browsers, Storybook, devices without a
+// visible navigation bar -- the rule is inert.
+//
+// Four things are easy to get wrong and are not visible at the call sites:
+//
+//  1. Ionic's utility classes out-specify a page rule. `.ion-no-padding` sets
+//     `--padding-bottom: 0` at specificity (0,1,0), while `sc-page-x
+//     ion-content` is (0,0,2) and loses silently -- match the class too, as
+//     page-multi-audio-station does. A page that later gains `.ion-padding`
+//     has to pass `var(--ion-padding, 16px)` as `$base`.
+//  2. The two mechanisms sum: `.inner-scroll` adds `--padding-bottom` *and*
+//     `--internal-content-safe-area-padding-bottom`. Should Ionic ever set the
+//     internal variable outside modals, every page doing both would get the
+//     inset twice. Re-check on Ionic upgrades.
+//  3. Page stylesheets are global (#95), so each rule has to be nested under
+//     its host tag. `page-language` and `page-error` are `shadow: true`, where
+//     a bare `ion-content` selector is already scoped.
+//  4. Do not also shorten the element inside the content. `sc-page-stations`
+//     carried a one-off `#player-list { margin-bottom: ... }` for #96; it is
+//     gone, because the two would apply the inset twice.
+//
+// The `@if` is not just tidiness: without a base the computed value of the
+// custom property is exactly the inset, which is what the specs assert. An
+// unconditional `calc()` would compute to the literal `calc(0px + 48px)`, since
+// an unregistered custom property computes to its substituted token stream
+// rather than to an evaluated length.
+@mixin content-bottom-inset($base: null) {
+  @if $base == null {
+    --padding-bottom: var(--ion-safe-area-bottom, 0px);
+  } @else {
+    --padding-bottom: calc(#{$base} + var(--ion-safe-area-bottom, 0px));
+  }
+}


### PR DESCRIPTION
Closes #101.

## What was wrong

Under an edge-to-edge WebView Ionic applies the bottom safe-area inset only in the components that own
the bottom edge — in `@ionic/core@8.8.18` exactly `ion-footer`, `ion-tab-bar`, `ion-toast` and
`ion-picker-legacy`. `ion-content` has the hook but nothing fills it:

```css
.inner-scroll {
  padding-bottom: calc(var(--padding-bottom) + var(--keyboard-offset) + var(--offset-bottom)
                       + var(--internal-content-safe-area-padding-bottom, 0px));
}
```

`--internal-content-safe-area-padding-bottom` is set by `ion-modal.applyFullscreenSafeAreaTo()` and
nowhere else. A routed page's `ion-content` therefore gets nothing, `fullscreen` or not, so every page
whose content reaches the bottom edge had its lowest element under the Android navigation bar — not
just `sc-page-stations`, which #96 fixed on its own.

## The fix

One mechanism, applied the same way everywhere: `--padding-bottom` on the page's `ion-content`, via a
shared mixin in `packages/ui/src/styles/_safe-area.scss`. That file is where the reasoning lives — the
call sites are a single `@include` each.

| Page | Selector | Base |
| --- | --- | --- |
| `page-station-list` | `sc-page-station-list ion-content` | – |
| `page-station-image-list` | `sc-page-station-image-list ion-content` | – |
| `page-tour-list` | `sc-page-tour-list ion-content` | – |
| `page-station` | `#station ion-content` | – |
| `page-pin` | `sc-page-pin ion-content` | – |
| `page-error` | `ion-content` (`shadow: true`) | – |
| `page-language` | `ion-content` (`shadow: true`) | `12px` |
| `page-multi-audio-station` | `#multi-audio-station ion-content.ion-no-padding` | – |
| `page-stations` | `sc-page-stations ion-content` | – |

Two needed more than a rule:

- **`page-language`** was the only page with a `.css` stylesheet; renamed to `.scss` so it can use the
  mixin, `styleUrl` updated. Its existing `12px` became the base the inset is *added* to, not replaced
  by — `calc(12px + var(--ion-safe-area-bottom, 0px))`.
- **`page-multi-audio-station`** has to name the class. `.ion-no-padding` sets `--padding-bottom: 0` at
  specificity (0,1,0); a bare `ion-content` selector would lose to it silently. The class also keeps the
  rule off the `ion-content.ion-padding` inside the page's popover.

## Reverting #96

`#player-list { margin-bottom: var(--ion-safe-area-bottom, 0px) }` is gone, replaced by the general form.

#96 ruled out `padding-bottom` **on `#player-list`**, because swiper sizes its viewport from that
container's `clientHeight` and the slides would just extend into the padded region. `--padding-bottom` on
the *content* is a different lever: it shortens `.inner-scroll`'s content box, so `#player-main` — sized
from it at `height: 100%` — ends above the navigation bar and takes the swiper with it. #96 measured both
at `#player-list` bottom = 875 on a 923px screen.

## `sc-page-tabbed-station-list`: deliberately unchanged

#101 point 5 expected the inner pages to double up with the tab bar compensation. They don't — the two
are complementary:

```
clearance needed = tab bar height = 56px + inset   (ion-tab-bar carries padding-bottom: var(--ion-safe-area-bottom, 0))

inner ion-content  --padding-bottom: inset
ion-list           margin-bottom:  56px
                                   ------------
total                              56px + inset
```

so the existing flat `ion-list { margin-bottom: 56px }` stays right, and no override is needed.

## Tests

`@ionic/core` is not loaded into the browser project (`vitest.setup.ts` imports only the built Stencil
bundle), so `ion-content` is an undefined element with no `.inner-scroll` to measure. The assertions read
the computed custom property instead — `getComputedStyle` still substitutes `var()` — in both halves the
#96 test established: the inset when `--ion-safe-area-bottom` is set on `documentElement`, and `0px` when
it is not, since browsers and Storybook report no inset and the rule has to stay inert there.

- **New** `src/pages/bottom-safe-area.browser.tsx` — table-driven over seven pages.
- `page-multi-audio-station.browser.tsx` — its own case, since it is the page that trips the specificity trap.
- `page-stations.browser.tsx` — the existing block rewritten, plus a new assertion that `#player-list`'s
  margin is now `0px` even with the inset set. That one is what stops #96's margin being reintroduced
  alongside the general rule and applying the inset twice.

## Follow-ups

`sc-page-selection` and `sc-page-map` put their content in `slot="fixed"`, which `--padding-bottom` does
not reach. The selection numpad is centred and clears the bar; MapLibre's attribution control does sit in
the navigation-bar strip and wants its own rule on `.maplibregl-ctrl-bottom-right` — worth its own issue.

Once released, consumers can drop the `sc-page-stations #player-list { margin-bottom: … }` workaround and
the app-level `--padding-bottom` block over these page tags.

## Verification

`lint`, `format:check`, `depcruise`, `npm test` (118 passed, 1 skipped) and `check:publish` all pass.
Behaviour confirmed on device in the audioguide apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
